### PR TITLE
Refactor parameter formatting and add table name quoting

### DIFF
--- a/packages/tinqer-sql-pg-promise/src/expression-generator.ts
+++ b/packages/tinqer-sql-pg-promise/src/expression-generator.ts
@@ -169,11 +169,9 @@ function generateConstantExpression(expr: ConstantExpression): string {
  * Generate SQL for parameter references
  */
 function generateParameterExpression(expr: ParameterExpression, context: SqlContext): string {
-  // For pg-promise, use :paramName or :param.property notation
-  if (expr.property) {
-    return `${context.paramPrefix}${expr.param}.${expr.property}`;
-  }
-  return `${context.paramPrefix}${expr.param}`;
+  // Extract only the last property name for the parameter
+  const paramName = expr.property || expr.param;
+  return context.formatParameter(paramName);
 }
 
 /**

--- a/packages/tinqer-sql-pg-promise/src/generators/from.ts
+++ b/packages/tinqer-sql-pg-promise/src/generators/from.ts
@@ -9,7 +9,9 @@ import type { SqlContext } from "../types.js";
  * Generate FROM clause
  */
 export function generateFrom(operation: FromOperation, context: SqlContext): string {
-  const table = operation.schema ? `${operation.schema}.${operation.table}` : operation.table;
+  const table = operation.schema
+    ? `"${operation.schema}"."${operation.table}"`
+    : `"${operation.table}"`;
 
   // Generate a table alias if not already present
   if (!context.tableAliases.has(operation.table)) {

--- a/packages/tinqer-sql-pg-promise/src/sql-generator.ts
+++ b/packages/tinqer-sql-pg-promise/src/sql-generator.ts
@@ -52,7 +52,7 @@ export function generateSql(operation: QueryOperation, _params: unknown): string
   const context: SqlContext = {
     tableAliases: new Map(),
     aliasCounter: 0,
-    paramPrefix: ":",
+    formatParameter: (paramName: string) => `$(${paramName})`, // pg-promise format
   };
 
   // Handle special operations first

--- a/packages/tinqer-sql-pg-promise/src/types.ts
+++ b/packages/tinqer-sql-pg-promise/src/types.ts
@@ -16,7 +16,7 @@ export interface SqlResult<TParams> {
 export interface SqlContext {
   tableAliases: Map<string, string>;
   aliasCounter: number;
-  paramPrefix: string; // For pg-promise we use ":"
+  formatParameter: (paramName: string) => string; // Format parameter for SQL dialect
 }
 
 /**

--- a/packages/tinqer-sql-pg-promise/tests/aggregates.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/aggregates.test.ts
@@ -12,7 +12,7 @@ describe("Aggregate SQL Generation", () => {
     it("should generate COUNT(*)", () => {
       const result = query(() => from<{ id: number }>("users").count(), {});
 
-      expect(result.sql).to.equal("SELECT COUNT(*) FROM users AS t0");
+      expect(result.sql).to.equal('SELECT COUNT(*) FROM "users" AS t0');
     });
 
     it("should generate COUNT with WHERE", () => {
@@ -24,7 +24,7 @@ describe("Aggregate SQL Generation", () => {
         {},
       );
 
-      expect(result.sql).to.equal("SELECT COUNT(*) FROM users AS t0 WHERE isActive");
+      expect(result.sql).to.equal('SELECT COUNT(*) FROM "users" AS t0 WHERE isActive');
     });
   });
 
@@ -32,7 +32,7 @@ describe("Aggregate SQL Generation", () => {
     it("should generate SUM", () => {
       const result = query(() => from<{ amount: number }>("orders").sum((x) => x.amount), {});
 
-      expect(result.sql).to.equal("SELECT SUM(amount) FROM orders AS t0");
+      expect(result.sql).to.equal('SELECT SUM(amount) FROM "orders" AS t0');
     });
   });
 
@@ -40,7 +40,7 @@ describe("Aggregate SQL Generation", () => {
     it("should generate AVG", () => {
       const result = query(() => from<{ price: number }>("products").average((x) => x.price), {});
 
-      expect(result.sql).to.equal("SELECT AVG(price) FROM products AS t0");
+      expect(result.sql).to.equal('SELECT AVG(price) FROM "products" AS t0');
     });
   });
 
@@ -48,7 +48,7 @@ describe("Aggregate SQL Generation", () => {
     it("should generate MIN", () => {
       const result = query(() => from<{ age: number }>("users").min((x) => x.age), {});
 
-      expect(result.sql).to.equal("SELECT MIN(age) FROM users AS t0");
+      expect(result.sql).to.equal('SELECT MIN(age) FROM "users" AS t0');
     });
   });
 
@@ -56,7 +56,7 @@ describe("Aggregate SQL Generation", () => {
     it("should generate MAX", () => {
       const result = query(() => from<{ salary: number }>("employees").max((x) => x.salary), {});
 
-      expect(result.sql).to.equal("SELECT MAX(salary) FROM employees AS t0");
+      expect(result.sql).to.equal('SELECT MAX(salary) FROM "employees" AS t0');
     });
   });
 });

--- a/packages/tinqer-sql-pg-promise/tests/chaining.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/chaining.test.ts
@@ -20,7 +20,7 @@ describe("Complex Query Chaining", () => {
     );
 
     expect(result.sql).to.equal(
-      "SELECT id AS id, name AS name FROM users AS t0 WHERE (age >= :p.minAge AND isActive) ORDER BY name ASC LIMIT 10",
+      'SELECT id AS id, name AS name FROM "users" AS t0 WHERE (age >= $(minAge) AND isActive) ORDER BY name ASC LIMIT 10',
     );
     expect(result.params).to.deep.equal({ minAge: 18 });
   });
@@ -36,7 +36,7 @@ describe("Complex Query Chaining", () => {
     );
 
     expect(result.sql).to.equal(
-      "SELECT * FROM products AS t0 ORDER BY name ASC LIMIT :p.pageSize OFFSET (:p.page * :p.pageSize)",
+      'SELECT * FROM "products" AS t0 ORDER BY name ASC LIMIT $(pageSize) OFFSET ($(page) * $(pageSize))',
     );
     expect(result.params).to.deep.equal({ page: 2, pageSize: 20 });
   });
@@ -50,7 +50,7 @@ describe("Complex Query Chaining", () => {
       {},
     );
 
-    expect(result.sql).to.equal("SELECT * FROM users AS t0 WHERE age >= 18 WHERE role = 'admin'");
+    expect(result.sql).to.equal('SELECT * FROM "users" AS t0 WHERE age >= 18 WHERE role = \'admin\'');
   });
 
   it("should generate query with DISTINCT", () => {
@@ -62,7 +62,7 @@ describe("Complex Query Chaining", () => {
       {},
     );
 
-    expect(result.sql).to.equal("SELECT DISTINCT category FROM products AS t0");
+    expect(result.sql).to.equal('SELECT DISTINCT category FROM "products" AS t0');
   });
 
   it.skip("should generate query with GROUP BY (parser limitation - grouping with aggregates)", () => {

--- a/packages/tinqer-sql-pg-promise/tests/distinct.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/distinct.test.ts
@@ -14,7 +14,7 @@ describe("Distinct SQL Generation", () => {
   it("should generate DISTINCT for all columns", () => {
     const result = query(() => from<Product>("products").distinct(), {});
 
-    expect(result.sql).to.equal("SELECT DISTINCT * FROM products AS t0");
+    expect(result.sql).to.equal('SELECT DISTINCT * FROM "products" AS t0');
   });
 
   it("should combine DISTINCT with WHERE", () => {
@@ -26,7 +26,7 @@ describe("Distinct SQL Generation", () => {
       {},
     );
 
-    expect(result.sql).to.equal("SELECT DISTINCT * FROM products AS t0 WHERE price > 100");
+    expect(result.sql).to.equal('SELECT DISTINCT * FROM "products" AS t0 WHERE price > 100');
   });
 
   it("should combine DISTINCT with SELECT projection", () => {
@@ -38,7 +38,7 @@ describe("Distinct SQL Generation", () => {
       {},
     );
 
-    expect(result.sql).to.equal("SELECT DISTINCT category AS category FROM products AS t0");
+    expect(result.sql).to.equal('SELECT DISTINCT category AS category FROM "products" AS t0');
   });
 
   it("should work with DISTINCT, WHERE, and ORDER BY", () => {
@@ -52,7 +52,7 @@ describe("Distinct SQL Generation", () => {
     );
 
     expect(result.sql).to.equal(
-      "SELECT DISTINCT * FROM products AS t0 WHERE price < 500 ORDER BY brand ASC",
+      'SELECT DISTINCT * FROM "products" AS t0 WHERE price < 500 ORDER BY brand ASC',
     );
   });
 });

--- a/packages/tinqer-sql-pg-promise/tests/from.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/from.test.ts
@@ -11,19 +11,19 @@ describe("FROM SQL Generation", () => {
   it("should generate simple FROM clause", () => {
     const result = query(() => from<{ id: number; name: string }>("users"), {});
 
-    expect(result.sql).to.equal("SELECT * FROM users AS t0");
+    expect(result.sql).to.equal('SELECT * FROM "users" AS t0');
     expect(result.params).to.deep.equal({});
   });
 
   it("should handle different table names", () => {
     const result = query(() => from<{ id: number }>("products"), {});
 
-    expect(result.sql).to.equal("SELECT * FROM products AS t0");
+    expect(result.sql).to.equal('SELECT * FROM "products" AS t0');
   });
 
   it("should handle table names with underscores", () => {
     const result = query(() => from<{ id: number }>("user_accounts"), {});
 
-    expect(result.sql).to.equal("SELECT * FROM user_accounts AS t0");
+    expect(result.sql).to.equal('SELECT * FROM "user_accounts" AS t0');
   });
 });

--- a/packages/tinqer-sql-pg-promise/tests/groupby.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/groupby.test.ts
@@ -15,7 +15,7 @@ describe("GroupBy SQL Generation", () => {
   it("should generate GROUP BY clause", () => {
     const result = query(() => from<Sale>("sales").groupBy((s) => s.category), {});
 
-    expect(result.sql).to.equal("SELECT * FROM sales AS t0 GROUP BY category");
+    expect(result.sql).to.equal('SELECT * FROM "sales" AS t0 GROUP BY category');
   });
 
   it("should combine GROUP BY with WHERE", () => {
@@ -27,7 +27,7 @@ describe("GroupBy SQL Generation", () => {
       {},
     );
 
-    expect(result.sql).to.equal("SELECT * FROM sales AS t0 WHERE amount > 100 GROUP BY category");
+    expect(result.sql).to.equal('SELECT * FROM "sales" AS t0 WHERE amount > 100 GROUP BY category');
   });
 
   it("should handle GROUP BY with SELECT projection", () => {
@@ -39,7 +39,7 @@ describe("GroupBy SQL Generation", () => {
       {},
     );
 
-    expect(result.sql).to.equal("SELECT key AS category FROM sales AS t0 GROUP BY category");
+    expect(result.sql).to.equal('SELECT key AS category FROM "sales" AS t0 GROUP BY category');
   });
 
   it("should work with GROUP BY and ORDER BY", () => {
@@ -51,6 +51,6 @@ describe("GroupBy SQL Generation", () => {
       {},
     );
 
-    expect(result.sql).to.equal("SELECT * FROM sales AS t0 GROUP BY product ORDER BY key ASC");
+    expect(result.sql).to.equal('SELECT * FROM "sales" AS t0 GROUP BY product ORDER BY key ASC');
   });
 });

--- a/packages/tinqer-sql-pg-promise/tests/orderby.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/orderby.test.ts
@@ -14,7 +14,7 @@ describe("ORDER BY SQL Generation", () => {
       {},
     );
 
-    expect(result.sql).to.equal("SELECT * FROM users AS t0 ORDER BY name ASC");
+    expect(result.sql).to.equal('SELECT * FROM "users" AS t0 ORDER BY name ASC');
   });
 
   it("should generate ORDER BY DESC", () => {
@@ -23,7 +23,7 @@ describe("ORDER BY SQL Generation", () => {
       {},
     );
 
-    expect(result.sql).to.equal("SELECT * FROM posts AS t0 ORDER BY createdAt DESC");
+    expect(result.sql).to.equal('SELECT * FROM "posts" AS t0 ORDER BY createdAt DESC');
   });
 
   it("should generate ORDER BY with THEN BY", () => {
@@ -35,7 +35,7 @@ describe("ORDER BY SQL Generation", () => {
       {},
     );
 
-    expect(result.sql).to.equal("SELECT * FROM products AS t0 ORDER BY category ASC, name ASC");
+    expect(result.sql).to.equal('SELECT * FROM "products" AS t0 ORDER BY category ASC, name ASC');
   });
 
   it("should generate mixed ORDER BY and THEN BY DESC", () => {
@@ -49,7 +49,7 @@ describe("ORDER BY SQL Generation", () => {
     );
 
     expect(result.sql).to.equal(
-      "SELECT * FROM products AS t0 ORDER BY category ASC, rating DESC, price ASC",
+      'SELECT * FROM "products" AS t0 ORDER BY category ASC, rating DESC, price ASC',
     );
   });
 });

--- a/packages/tinqer-sql-pg-promise/tests/select.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/select.test.ts
@@ -14,7 +14,7 @@ describe("SELECT SQL Generation", () => {
       {},
     );
 
-    expect(result.sql).to.equal("SELECT name FROM users AS t0");
+    expect(result.sql).to.equal('SELECT name FROM "users" AS t0');
   });
 
   it("should generate SELECT with object projection", () => {
@@ -27,7 +27,7 @@ describe("SELECT SQL Generation", () => {
       {},
     );
 
-    expect(result.sql).to.equal("SELECT id AS userId, name AS userName FROM users AS t0");
+    expect(result.sql).to.equal('SELECT id AS userId, name AS userName FROM "users" AS t0');
   });
 
   it("should generate SELECT with computed values", () => {
@@ -41,7 +41,7 @@ describe("SELECT SQL Generation", () => {
     );
 
     expect(result.sql).to.equal(
-      "SELECT firstName || ' ' || lastName AS fullName, (age * 12) AS ageInMonths FROM users AS t0",
+      "SELECT firstName || ' ' || lastName AS fullName, (age * 12) AS ageInMonths FROM \"users\" AS t0",
     );
   });
 
@@ -54,6 +54,6 @@ describe("SELECT SQL Generation", () => {
       {},
     );
 
-    expect(result.sql).to.equal("SELECT id AS id, name AS name FROM users AS t0 WHERE age >= 18");
+    expect(result.sql).to.equal('SELECT id AS id, name AS name FROM "users" AS t0 WHERE age >= 18');
   });
 });

--- a/packages/tinqer-sql-pg-promise/tests/skip.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/skip.test.ts
@@ -13,13 +13,13 @@ describe("Skip SQL Generation", () => {
   it("should generate OFFSET clause", () => {
     const result = query(() => from<User>("users").skip(10), {});
 
-    expect(result.sql).to.equal("SELECT * FROM users AS t0 OFFSET 10");
+    expect(result.sql).to.equal('SELECT * FROM "users" AS t0 OFFSET 10');
   });
 
   it("should combine skip with take for pagination", () => {
     const result = query(() => from<User>("users").skip(20).take(10), {});
 
-    expect(result.sql).to.equal("SELECT * FROM users AS t0 LIMIT 10 OFFSET 20");
+    expect(result.sql).to.equal('SELECT * FROM "users" AS t0 LIMIT 10 OFFSET 20');
   });
 
   it("should combine skip with where and orderBy", () => {
@@ -33,7 +33,7 @@ describe("Skip SQL Generation", () => {
     );
 
     expect(result.sql).to.equal(
-      "SELECT * FROM users AS t0 WHERE age >= 21 ORDER BY name ASC OFFSET 5",
+      'SELECT * FROM "users" AS t0 WHERE age >= 21 ORDER BY name ASC OFFSET 5',
     );
   });
 

--- a/packages/tinqer-sql-pg-promise/tests/take.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/take.test.ts
@@ -13,13 +13,13 @@ describe("Take SQL Generation", () => {
   it("should generate LIMIT clause", () => {
     const result = query(() => from<User>("users").take(10), {});
 
-    expect(result.sql).to.equal("SELECT * FROM users AS t0 LIMIT 10");
+    expect(result.sql).to.equal('SELECT * FROM "users" AS t0 LIMIT 10');
   });
 
   it("should handle take(1)", () => {
     const result = query(() => from<User>("users").take(1), {});
 
-    expect(result.sql).to.equal("SELECT * FROM users AS t0 LIMIT 1");
+    expect(result.sql).to.equal('SELECT * FROM "users" AS t0 LIMIT 1');
   });
 
   it("should combine take with where", () => {
@@ -31,7 +31,7 @@ describe("Take SQL Generation", () => {
       {},
     );
 
-    expect(result.sql).to.equal("SELECT * FROM users AS t0 WHERE age > 18 LIMIT 5");
+    expect(result.sql).to.equal('SELECT * FROM "users" AS t0 WHERE age > 18 LIMIT 5');
   });
 
   it("should combine take with orderBy", () => {
@@ -43,6 +43,6 @@ describe("Take SQL Generation", () => {
       {},
     );
 
-    expect(result.sql).to.equal("SELECT * FROM users AS t0 ORDER BY name ASC LIMIT 3");
+    expect(result.sql).to.equal('SELECT * FROM "users" AS t0 ORDER BY name ASC LIMIT 3');
   });
 });

--- a/packages/tinqer-sql-pg-promise/tests/where.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/where.test.ts
@@ -15,7 +15,7 @@ describe("WHERE SQL Generation", () => {
         {},
       );
 
-      expect(result.sql).to.equal("SELECT * FROM users AS t0 WHERE id = 1");
+      expect(result.sql).to.equal('SELECT * FROM "users" AS t0 WHERE id = 1');
     });
 
     it("should generate greater than comparison", () => {
@@ -24,7 +24,7 @@ describe("WHERE SQL Generation", () => {
         {},
       );
 
-      expect(result.sql).to.equal("SELECT * FROM users AS t0 WHERE age > 18");
+      expect(result.sql).to.equal('SELECT * FROM "users" AS t0 WHERE age > 18');
     });
 
     it("should generate greater than or equal comparison", () => {
@@ -33,7 +33,7 @@ describe("WHERE SQL Generation", () => {
         {},
       );
 
-      expect(result.sql).to.equal("SELECT * FROM users AS t0 WHERE age >= 18");
+      expect(result.sql).to.equal('SELECT * FROM "users" AS t0 WHERE age >= 18');
     });
   });
 
@@ -47,7 +47,7 @@ describe("WHERE SQL Generation", () => {
         {},
       );
 
-      expect(result.sql).to.equal("SELECT * FROM users AS t0 WHERE (age >= 18 AND isActive)");
+      expect(result.sql).to.equal('SELECT * FROM "users" AS t0 WHERE (age >= 18 AND isActive)');
     });
 
     it("should generate OR condition", () => {
@@ -60,7 +60,7 @@ describe("WHERE SQL Generation", () => {
       );
 
       expect(result.sql).to.equal(
-        "SELECT * FROM users AS t0 WHERE (role = 'admin' OR role = 'moderator')",
+        'SELECT * FROM "users" AS t0 WHERE (role = \'admin\' OR role = \'moderator\')',
       );
     });
   });
@@ -73,7 +73,7 @@ describe("WHERE SQL Generation", () => {
         { minAge: 18 },
       );
 
-      expect(result.sql).to.equal("SELECT * FROM users AS t0 WHERE age >= :p.minAge");
+      expect(result.sql).to.equal('SELECT * FROM "users" AS t0 WHERE age >= $(minAge)');
       expect(result.params).to.deep.equal({ minAge: 18 });
     });
 
@@ -87,7 +87,7 @@ describe("WHERE SQL Generation", () => {
       );
 
       expect(result.sql).to.equal(
-        "SELECT * FROM users AS t0 WHERE (age >= :p.minAge AND age <= :p.maxAge)",
+        'SELECT * FROM "users" AS t0 WHERE (age >= $(minAge) AND age <= $(maxAge))',
       );
       expect(result.params).to.deep.equal({ minAge: 18, maxAge: 65 });
     });


### PR DESCRIPTION
- Replace paramPrefix with formatParameter function for flexibility
- Extract only last property from parameter expressions (p.age → age)
- Use pg-promise $(paramName) format instead of :p.property
- Add quotes around all table names for PostgreSQL compatibility
- Update all tests to match new SQL output format
- All 43 tests passing, architecture now cleaner and more extensible

🤖 Generated with [Claude Code](https://claude.ai/code)