### PR TITLE
refactor: remove ESM compatibility options for stricter module config…

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,6 @@
     "moduleResolution": "NodeNext",
     "lib": ["ES2020"],
     "strict": true,
-    "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
@@ -17,8 +16,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
-    "allowSyntheticDefaultImports": true
+    "noUncheckedIndexedAccess": true
   },
   "exclude": ["node_modules", "dist", "build", "coverage"]
 }


### PR DESCRIPTION
…uration

- Remove esModuleInterop from tsconfig
- Remove allowSyntheticDefaultImports
- Enforce pure ESM without CommonJS compatibility layers
- All tests pass with stricter configuration

🤖 Generated with [Claude Code](https://claude.ai/code)