### PR TITLE
test: remove pending tests from integration test suite

### DIFF
--- a/packages/tinqer-sql-pg-promise-integration/tests/joins.test.ts
+++ b/packages/tinqer-sql-pg-promise-integration/tests/joins.test.ts
@@ -201,56 +201,6 @@ describe("PostgreSQL Integration - JOINs", () => {
   });
 
   describe("Complex JOIN scenarios", () => {
-    it.skip("should find top products by revenue - LIMITATION: pass-through properties in chained JOINs", async () => {
-      const results = await executeSimple(db, () =>
-        from(dbContext, "order_items")
-          .join(
-            from(dbContext, "products"),
-            (oi) => oi.product_id,
-            (p) => p.id,
-            (oi, p) => ({
-              orderItemId: oi.id,
-              orderId: oi.order_id,
-              quantity: oi.quantity,
-              unitPrice: oi.unit_price,
-              productId: p.id,
-              productName: p.name,
-            }),
-          )
-          .join(
-            from(dbContext, "orders"),
-            (joined) => joined.orderId,
-            (o) => o.id,
-            (joined, o) => ({
-              orderItemId: joined.orderItemId,
-              quantity: joined.quantity,
-              unitPrice: joined.unitPrice,
-              productId: joined.productId,
-              productName: joined.productName,
-              orderStatus: o.status,
-            }),
-          )
-          .where((joined) => joined.orderStatus === "completed")
-          .groupBy((joined) => ({ id: joined.productId, name: joined.productName }))
-          .select((g) => ({
-            productId: g.key.id,
-            productName: g.key.name,
-            unitsSold: g.sum((joined) => joined.quantity),
-            revenue: g.sum((joined) => joined.quantity * joined.unitPrice),
-          }))
-          .orderByDescending((p) => p.revenue)
-          .take(5),
-      );
-
-      expect(results).to.be.an("array");
-      expect(results.length).to.be.at.most(5);
-
-      // Check that results are properly ordered by revenue
-      for (let i = 1; i < results.length; i++) {
-        expect(results[i - 1]!.revenue).to.be.at.least(results[i]!.revenue);
-      }
-    });
-
     it("should find customers with high-value orders", async () => {
       const results = await executeSimple(db, () =>
         from(dbContext, "users")
@@ -276,59 +226,6 @@ describe("PostgreSQL Integration - JOINs", () => {
       expect(results.length).to.be.greaterThan(0);
       results.forEach((r) => {
         expect(r.orderAmount).to.be.greaterThan(500);
-      });
-    });
-
-    it.skip("should analyze department spending - LIMITATION: pass-through properties in chained JOINs", async () => {
-      const results = await executeSimple(db, () =>
-        from(dbContext, "departments")
-          .join(
-            from(dbContext, "users"),
-            (d) => d.id,
-            (u) => u.department_id,
-            (d, u) => ({
-              departmentId: d.id,
-              departmentName: d.name,
-              departmentBudget: d.budget,
-              userId: u.id,
-            }),
-          )
-          .join(
-            from(dbContext, "orders"),
-            (joined) => joined.userId,
-            (o) => o.user_id,
-            (joined, o) => ({
-              departmentId: joined.departmentId,
-              departmentName: joined.departmentName,
-              departmentBudget: joined.departmentBudget,
-              orderId: o.id,
-              orderAmount: o.total_amount,
-            }),
-          )
-          .groupBy((joined) => ({
-            id: joined.departmentId,
-            name: joined.departmentName,
-            budget: joined.departmentBudget,
-          }))
-          .select((g) => ({
-            departmentId: g.key.id,
-            departmentName: g.key.name,
-            budget: g.key.budget,
-            totalSpending: g.sum((joined) => joined.orderAmount),
-            orderCount: g.count(),
-            avgOrderValue: g.average((joined) => joined.orderAmount),
-          })),
-      );
-
-      expect(results).to.be.an("array");
-      expect(results.length).to.be.greaterThan(0);
-      results.forEach((r) => {
-        expect(r).to.have.property("departmentId");
-        expect(r).to.have.property("departmentName");
-        expect(r).to.have.property("budget");
-        expect(r).to.have.property("totalSpending");
-        expect(r).to.have.property("orderCount");
-        expect(r).to.have.property("avgOrderValue");
       });
     });
   });

--- a/packages/tinqer/src/visitors/select/projection.ts
+++ b/packages/tinqer/src/visitors/select/projection.ts
@@ -259,7 +259,7 @@ function visitColumnProjection(node: MemberExpression, context: SelectContext): 
             };
           } else if (shapeProp && shapeProp.type === "object") {
             // It's a nested object - look deeper
-            const nestedShape = shapeProp as { type: "object"; properties: Map<string, any> };
+            const nestedShape = shapeProp as { type: "object"; properties: Map<string, unknown> };
             const deepProp = nestedShape.properties.get(propertyName);
 
             if (deepProp && deepProp.type === "reference") {


### PR DESCRIPTION
Remove two skipped tests that were testing limitations with pass-through properties in chained JOINs:
- "should find top products by revenue"
- "should analyze department spending"

Also fixed a linting error by replacing 'any' with 'unknown' type.

🤖 Generated with [Claude Code](https://claude.ai/code)