### PR TITLE
refactor: update test imports to use dist instead of src

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ All examples assume TypeScript with `strict` enabled and ECMAScript modules.
 
 ## 2. Adapter Packages
 
-| Package                              | Purpose                                                                     | Notes                                                                  |
-| ------------------------------------ | --------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `@webpods/tinqer`                    | Core expression tree, visitors, and TypeScript types.                       | Not meant to be installed directly; the adapters re-export everything. |
-| `@webpods/tinqer-sql-pg-promise`     | SQL generator for PostgreSQL with pg-promise parameter markers (`$(name)`). | Provides `selectStatement`, `executeSelect`, `executeSelectSimple`, and `toSql`.             |
-| `@webpods/tinqer-sql-better-sqlite3` | SQL generator for SQLite using better-sqlite3 (`@name`).                    | Handles boolean conversion and date formatting before execution.       |
+| Package                              | Purpose                                                                     | Notes                                                                            |
+| ------------------------------------ | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `@webpods/tinqer`                    | Core expression tree, visitors, and TypeScript types.                       | Not meant to be installed directly; the adapters re-export everything.           |
+| `@webpods/tinqer-sql-pg-promise`     | SQL generator for PostgreSQL with pg-promise parameter markers (`$(name)`). | Provides `selectStatement`, `executeSelect`, `executeSelectSimple`, and `toSql`. |
+| `@webpods/tinqer-sql-better-sqlite3` | SQL generator for SQLite using better-sqlite3 (`@name`).                    | Handles boolean conversion and date formatting before execution.                 |
 
 Both adapters expose identical TypeScript APIs so query builders can be shared between them.
 
@@ -993,7 +993,10 @@ SELECT * FROM "users" WHERE "departmentId" = @__p1 AND "name" LIKE @__p2 || '%'
 ### 6.3 Array Membership (`Array.includes`)
 
 ```typescript
-const membership = selectStatement(() => from<User>("users").where((u) => [1, 2, 3].includes(u.id)), {});
+const membership = selectStatement(
+  () => from<User>("users").where((u) => [1, 2, 3].includes(u.id)),
+  {},
+);
 ```
 
 ```sql
@@ -1214,14 +1217,14 @@ const upcoming = selectStatement(
 
 ## 14. Troubleshooting
 
-| Symptom                                          | Cause                                                                                                    | Resolution                                                                           |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `Failed to parse query`                          | Lambda uses an unsupported construct (captured variable, named function, helper call, template literal). | Rewrite the lambda using the supported subset; pass values via the parameter object. |
-| `Unknown query method`                           | Fluent method (`union`, `selectMany`, `longCount`, etc.) not implemented.                                | Remove the call or implement support before using it.                                |
-| Query returns no rows for `last*`                | No ordering specified and result set is empty.                                                           | Provide an explicit `orderBy` or switch to `lastOrDefault`.                          |
-| SQLite booleans stored as `true`/`false` strings | Manual execution without adapter conversion.                                                             | Use `executeSelect`/`executeSelectSimple`, which convert booleans to integers.                   |
-| Auto-parameter names unfamiliar                  | Literals are auto-parameterised (`__pN`).                                                                | Use the `params` object returned by `selectStatement`; do not assume positional order.         |
-| Grouped projection filter acts like HAVING       | `where` after `groupBy` translates to a standard `WHERE`.                                                | Filter in application code or extend the generator for HAVING support.               |
+| Symptom                                          | Cause                                                                                                    | Resolution                                                                             |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `Failed to parse query`                          | Lambda uses an unsupported construct (captured variable, named function, helper call, template literal). | Rewrite the lambda using the supported subset; pass values via the parameter object.   |
+| `Unknown query method`                           | Fluent method (`union`, `selectMany`, `longCount`, etc.) not implemented.                                | Remove the call or implement support before using it.                                  |
+| Query returns no rows for `last*`                | No ordering specified and result set is empty.                                                           | Provide an explicit `orderBy` or switch to `lastOrDefault`.                            |
+| SQLite booleans stored as `true`/`false` strings | Manual execution without adapter conversion.                                                             | Use `executeSelect`/`executeSelectSimple`, which convert booleans to integers.         |
+| Auto-parameter names unfamiliar                  | Literals are auto-parameterised (`__pN`).                                                                | Use the `params` object returned by `selectStatement`; do not assume positional order. |
+| Grouped projection filter acts like HAVING       | `where` after `groupBy` translates to a standard `WHERE`.                                                | Filter in application code or extend the generator for HAVING support.                 |
 
 ---
 

--- a/packages/tinqer-sql-better-sqlite3/tests/case-insensitive-functions.test.ts
+++ b/packages/tinqer-sql-better-sqlite3/tests/case-insensitive-functions.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { selectStatement } from "../src/index.js";
+import { selectStatement } from "../dist/index.js";
 import { from, createQueryHelpers } from "@webpods/tinqer";
 
 type User = {

--- a/packages/tinqer-sql-better-sqlite3/tests/join-table-references.test.ts
+++ b/packages/tinqer-sql-better-sqlite3/tests/join-table-references.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { expect } from "chai";
-import { selectStatement } from "../src/index.js";
+import { selectStatement } from "../dist/index.js";
 import { from } from "@webpods/tinqer";
 
 interface User {

--- a/packages/tinqer-sql-pg-promise/tests/case-insensitive-functions.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/case-insensitive-functions.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { selectStatement } from "../src/index.js";
+import { selectStatement } from "../dist/index.js";
 import { from, createQueryHelpers } from "@webpods/tinqer";
 
 type User = {

--- a/packages/tinqer-sql-pg-promise/tests/join-table-references.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/join-table-references.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { expect } from "chai";
-import { selectStatement } from "../src/index.js";
+import { selectStatement } from "../dist/index.js";
 import { from } from "@webpods/tinqer";
 
 interface User {

--- a/packages/tinqer/tests/auto-param-field-context.test.ts
+++ b/packages/tinqer/tests/auto-param-field-context.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { parseQuery, from } from "../src/index.js";
+import { parseQuery, from } from "../dist/index.js";
 import { db } from "./test-schema.js";
 
 describe("Auto-Parameter Field Context", () => {

--- a/packages/tinqer/tests/auto-parameterization.test.ts
+++ b/packages/tinqer/tests/auto-parameterization.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { parseQuery, from } from "../src/index.js";
+import { parseQuery, from } from "../dist/index.js";
 import { getOperation } from "./test-utils/operation-helpers.js";
 import { db } from "./test-schema.js";
 

--- a/packages/tinqer/tests/case-insensitive-functions.test.ts
+++ b/packages/tinqer/tests/case-insensitive-functions.test.ts
@@ -4,17 +4,17 @@
 
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { parseQuery } from "../src/parser/parse-query.js";
-import { from } from "../src/linq/from.js";
-import { createQueryHelpers } from "../src/linq/functions.js";
-import type { DatabaseContext } from "../src/linq/database-context.js";
-import type { WhereOperation, SelectOperation } from "../src/query-tree/operations.js";
+import { parseQuery } from "../dist/parser/parse-query.js";
+import { from } from "../dist/linq/from.js";
+import { createQueryHelpers } from "../dist/linq/functions.js";
+import type { DatabaseContext } from "../dist/linq/database-context.js";
+import type { WhereOperation, SelectOperation } from "../dist/query-tree/operations.js";
 import type {
   CaseInsensitiveFunctionExpression,
   LogicalExpression,
   ColumnExpression,
   ParameterExpression,
-} from "../src/expressions/expression.js";
+} from "../dist/expressions/expression.js";
 
 type User = {
   id: number;

--- a/packages/tinqer/tests/chaining.test.ts
+++ b/packages/tinqer/tests/chaining.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { parseQuery, from } from "../src/index.js";
+import { parseQuery, from } from "../dist/index.js";
 import {
   asFromOperation,
   asWhereOperation,
@@ -14,8 +14,8 @@ import {
   asTakeOperation,
   getOperation,
 } from "./test-utils/operation-helpers.js";
-import type { ComparisonExpression, ColumnExpression } from "../src/expressions/expression.js";
-import type { ParamRef } from "../src/query-tree/operations.js";
+import type { ComparisonExpression, ColumnExpression } from "../dist/expressions/expression.js";
+import type { ParamRef } from "../dist/query-tree/operations.js";
 import { db } from "./test-schema.js";
 
 describe("Operation Chaining", () => {

--- a/packages/tinqer/tests/from.test.ts
+++ b/packages/tinqer/tests/from.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { parseQuery, from } from "../src/index.js";
+import { parseQuery, from } from "../dist/index.js";
 import { asFromOperation, getOperation } from "./test-utils/operation-helpers.js";
 import { db } from "./test-schema.js";
 

--- a/packages/tinqer/tests/groupby.test.ts
+++ b/packages/tinqer/tests/groupby.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { parseQuery, from } from "../src/index.js";
+import { parseQuery, from } from "../dist/index.js";
 import {
   asGroupByOperation,
   asSelectOperation,

--- a/packages/tinqer/tests/orderby.test.ts
+++ b/packages/tinqer/tests/orderby.test.ts
@@ -4,15 +4,15 @@
 
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { parseQuery, from } from "../src/index.js";
+import { parseQuery, from } from "../dist/index.js";
 import {
   asOrderByOperation,
   asSelectOperation,
   asTakeOperation,
   getOperation,
 } from "./test-utils/operation-helpers.js";
-import type { ConcatExpression } from "../src/expressions/expression.js";
-import type { ParamRef } from "../src/query-tree/operations.js";
+import type { ConcatExpression } from "../dist/expressions/expression.js";
+import type { ParamRef } from "../dist/query-tree/operations.js";
 import { db } from "./test-schema.js";
 
 describe("ORDER BY Operations", () => {

--- a/packages/tinqer/tests/parse-query-integration.test.ts
+++ b/packages/tinqer/tests/parse-query-integration.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { parseQuery, from } from "../src/index.js";
+import { parseQuery, from } from "../dist/index.js";
 import {
   asFromOperation,
   asWhereOperation,
@@ -13,14 +13,14 @@ import {
   asTakeOperation,
   getOperation,
 } from "./test-utils/operation-helpers.js";
-import type { ParamRef } from "../src/query-tree/operations.js";
+import type { ParamRef } from "../dist/query-tree/operations.js";
 import type {
   ComparisonExpression,
   ObjectExpression,
   LogicalExpression,
   BooleanMethodExpression,
   ColumnExpression,
-} from "../src/expressions/expression.js";
+} from "../dist/expressions/expression.js";
 import { db } from "./test-schema.js";
 
 describe("Parse Query Integration Tests", () => {

--- a/packages/tinqer/tests/select.test.ts
+++ b/packages/tinqer/tests/select.test.ts
@@ -4,10 +4,10 @@
 
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { parseQuery, from } from "../src/index.js";
+import { parseQuery, from } from "../dist/index.js";
 import { db } from "./test-schema.js";
 import { asSelectOperation, getOperation } from "./test-utils/operation-helpers.js";
-import type { ObjectExpression, ColumnExpression } from "../src/expressions/expression.js";
+import type { ObjectExpression, ColumnExpression } from "../dist/expressions/expression.js";
 
 describe("SELECT Operation", () => {
   describe("Simple Projections", () => {

--- a/packages/tinqer/tests/skip.test.ts
+++ b/packages/tinqer/tests/skip.test.ts
@@ -4,15 +4,15 @@
 
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { parseQuery, from } from "../src/index.js";
+import { parseQuery, from } from "../dist/index.js";
 import {
   asSkipOperation,
   asOrderByOperation,
   asTakeOperation,
   getOperation,
 } from "./test-utils/operation-helpers.js";
-import type { ParamRef } from "../src/query-tree/operations.js";
-import type { ArithmeticExpression } from "../src/expressions/expression.js";
+import type { ParamRef } from "../dist/query-tree/operations.js";
+import type { ArithmeticExpression } from "../dist/expressions/expression.js";
 import { db } from "./test-schema.js";
 
 describe("SKIP Operations", () => {

--- a/packages/tinqer/tests/take.test.ts
+++ b/packages/tinqer/tests/take.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { parseQuery, from } from "../src/index.js";
+import { parseQuery, from } from "../dist/index.js";
 import {
   asTakeOperation,
   asWhereOperation,
@@ -12,7 +12,7 @@ import {
   asSelectOperation,
   getOperation,
 } from "./test-utils/operation-helpers.js";
-import type { ParamRef } from "../src/query-tree/operations.js";
+import type { ParamRef } from "../dist/query-tree/operations.js";
 import { db } from "./test-schema.js";
 
 describe("TAKE Operation", () => {

--- a/packages/tinqer/tests/test-schema.ts
+++ b/packages/tinqer/tests/test-schema.ts
@@ -2,7 +2,7 @@
  * Shared test schema for all test files
  */
 
-import { createContext } from "../src/index.js";
+import { createContext } from "../dist/index.js";
 
 // Common test schema
 export interface TestSchema {

--- a/packages/tinqer/tests/thenby.test.ts
+++ b/packages/tinqer/tests/thenby.test.ts
@@ -4,13 +4,13 @@
 
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { parseQuery, from } from "../src/index.js";
+import { parseQuery, from } from "../dist/index.js";
 import {
   asOrderByOperation,
   asThenByOperation,
   getOperation,
 } from "./test-utils/operation-helpers.js";
-import type { ArithmeticExpression } from "../src/expressions/expression.js";
+import type { ArithmeticExpression } from "../dist/expressions/expression.js";
 import { db } from "./test-schema.js";
 
 describe("THEN BY Operations", () => {

--- a/packages/tinqer/tests/where.test.ts
+++ b/packages/tinqer/tests/where.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { parseQuery, from } from "../src/index.js";
+import { parseQuery, from } from "../dist/index.js";
 import { db } from "./test-schema.js";
 import { expr } from "./test-utils/expr-helpers.js";
 import { asWhereOperation, getOperation } from "./test-utils/operation-helpers.js";
@@ -14,8 +14,8 @@ import type {
   ColumnExpression,
   ConstantExpression,
   ParameterExpression,
-} from "../src/expressions/expression.js";
-import type { ParamRef } from "../src/query-tree/operations.js";
+} from "../dist/expressions/expression.js";
+import type { ParamRef } from "../dist/query-tree/operations.js";
 
 describe("WHERE Operation", () => {
   describe("Comparison Operators", () => {


### PR DESCRIPTION
- Changed all test imports from src/ to dist/ directories
- Tests now run against compiled code rather than source TypeScript
- Ensures tests validate the actual published artifacts
- Updated core package tests (tinqer)
- Updated adapter package tests (pg-promise, better-sqlite3)
- Minor README formatting improvements for table alignment

This change makes tests more representative of the actual package behavior that consumers will experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)