### PR TITLE
docs: update documentation to remove toArray/toList/longCount references

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -481,7 +481,6 @@ class Queryable<T> {
   // Terminal operations
   count(predicate?: (item: T) => boolean): TerminalQuery<number>;
   first(predicate?: (item: T) => boolean): TerminalQuery<T>;
-  toArray(): TerminalQuery<T[]>;
 }
 
 // Terminal query marker

--- a/CODING-STANDARDS.md
+++ b/CODING-STANDARDS.md
@@ -322,8 +322,8 @@ Operations should build expression trees without immediate processing.
 const query = users.where((u) => u.age >= 18).select((u) => u.name);
 // No database hit yet
 
-// Terminal operation triggers execution
-const results = query.toArray();
+// Execution happens when passed to executeSelect/executeSelectSimple
+const results = await executeSelect(db, () => query, {});
 ```
 
 ### Expression Reuse

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -795,7 +795,7 @@ SELECT * FROM "users" ORDER BY "createdAt" ASC LIMIT 1
 
 ## 11. Materialisation
 
-The `toArray` method executes the query without adding additional clauses.
+Queries are executed directly without requiring a materialization method. The query builder returns results as arrays by default.
 
 ```typescript
 const activeUsers = await executeSelect(
@@ -803,13 +803,12 @@ const activeUsers = await executeSelect(
   () =>
     from<User>("users")
       .where((u) => u.active)
-      .orderBy((u) => u.name)
-      .toArray(),
+      .orderBy((u) => u.name),
   {},
 );
 ```
 
-The generated SQL matches the chain preceding `toArray`.
+The generated SQL matches the entire query chain.
 
 ---
 


### PR DESCRIPTION
Updated documentation to reflect API changes:
- Removed toArray() examples - queries execute directly as arrays
- Removed toList() references
- Updated ARCHITECTURE.md to remove toArray() from interface examples
- Updated CODING-STANDARDS.md with proper execution pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)