### PR TITLE
docs: update SQLite examples to show executeSelect with params

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const results = await executeSelectSimple(db, () =>
 ```typescript
 import Database from "better-sqlite3";
 import { createContext, from } from "@webpods/tinqer";
-import { executeSelectSimple, selectStatement } from "@webpods/tinqer-sql-better-sqlite3";
+import { executeSelect, selectStatement } from "@webpods/tinqer-sql-better-sqlite3";
 
 interface Schema {
   products: {
@@ -64,11 +64,14 @@ interface Schema {
 const db = new Database("./data.db");
 const ctx = createContext<Schema>();
 
-const results = executeSelectSimple(db, () =>
-  from(ctx, "products")
-    .where((p) => p.inStock === 1 && p.price < 100)
-    .orderByDescending((p) => p.price)
-    .select((p) => p),
+const results = executeSelect(
+  db,
+  (params: { maxPrice: number }) =>
+    from(ctx, "products")
+      .where((p) => p.inStock === 1 && p.price < params.maxPrice)
+      .orderByDescending((p) => p.price)
+      .select((p) => p),
+  { maxPrice: 100 },
 );
 
 // Need the raw SQL for logging or prepared statements? selectStatement is still available:

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -127,7 +127,6 @@ import Database from "better-sqlite3";
 import { createContext, from, insertInto, updateTable, deleteFrom } from "@webpods/tinqer";
 import {
   executeSelect,
-  executeSelectSimple,
   executeInsert,
   executeUpdate,
   executeDelete,
@@ -158,10 +157,13 @@ const inserted = executeInsert(
 );
 // inserted === 1
 
-const users = executeSelectSimple(db, () =>
-  from(ctx, "users")
-    .where((u) => u.isActive === 1)
-    .orderBy((u) => u.name),
+const users = executeSelect(
+  db,
+  (params: { active: number }) =>
+    from(ctx, "users")
+      .where((u) => u.isActive === params.active)
+      .orderBy((u) => u.name),
+  { active: 1 },
 );
 
 const updated = executeUpdate(


### PR DESCRIPTION
Updated documentation to demonstrate executeSelect with params pattern instead of executeSelectSimple in SQLite examples, showing consistent API usage with explicit parameter passing across both adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)