### PR TITLE
fix: expand array parameters to IN clause for better type safety

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4187,7 +4187,7 @@
     },
     "packages/tinqer": {
       "name": "@webpods/tinqer",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "oxc-parser": "^0.90.0"
@@ -4228,7 +4228,7 @@
     },
     "packages/tinqer-sql-better-sqlite3": {
       "name": "@webpods/tinqer-sql-better-sqlite3",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",
@@ -4241,12 +4241,12 @@
         "typescript": "5.9.2"
       },
       "peerDependencies": {
-        "@webpods/tinqer": "^0.0.4"
+        "@webpods/tinqer": "^0.0.5"
       }
     },
     "packages/tinqer-sql-better-sqlite3-integration": {
       "name": "@webpods/tinqer-sql-better-sqlite3-integration",
-      "version": "0.0.2",
+      "version": "0.0.5",
       "dependencies": {
         "@webpods/tinqer": "file:../tinqer",
         "@webpods/tinqer-sql-better-sqlite3": "file:../tinqer-sql-better-sqlite3",
@@ -4265,7 +4265,7 @@
     },
     "packages/tinqer-sql-pg-promise": {
       "name": "@webpods/tinqer-sql-pg-promise",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "5.2.2",
@@ -4278,12 +4278,12 @@
         "typescript": "5.9.2"
       },
       "peerDependencies": {
-        "@webpods/tinqer": "^0.0.4"
+        "@webpods/tinqer": "^0.0.5"
       }
     },
     "packages/tinqer-sql-pg-promise-integration": {
       "name": "@webpods/tinqer-sql-pg-promise-integration",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "dependencies": {
         "@webpods/tinqer": "file:../tinqer",
         "@webpods/tinqer-sql-pg-promise": "file:../tinqer-sql-pg-promise",

--- a/packages/tinqer-sql-better-sqlite3-integration/package.json
+++ b/packages/tinqer-sql-better-sqlite3-integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer-sql-better-sqlite3-integration",
-  "version": "0.0.2",
+  "version": "0.0.5",
   "private": true,
   "type": "module",
   "description": "SQLite integration tests for Tinqer using better-sqlite3",

--- a/packages/tinqer-sql-better-sqlite3/package.json
+++ b/packages/tinqer-sql-better-sqlite3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer-sql-better-sqlite3",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Better SQLite3 SQL generator for Tinqer query builder",
   "type": "module",
   "main": "./dist/index.js",
@@ -19,7 +19,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@webpods/tinqer": "^0.0.4"
+    "@webpods/tinqer": "^0.0.5"
   },
   "devDependencies": {
     "@types/chai": "5.2.2",

--- a/packages/tinqer-sql-better-sqlite3/src/index.ts
+++ b/packages/tinqer-sql-better-sqlite3/src/index.ts
@@ -20,6 +20,24 @@ import { generateSql } from "./sql-generator.js";
 import type { SqlResult, ExecuteOptions } from "./types.js";
 
 /**
+ * Helper function to expand array parameters into indexed parameters
+ * e.g., { ids: [1, 2, 3] } becomes { ids: [1, 2, 3], "ids_0": 1, "ids_1": 2, "ids_2": 3 }
+ */
+function expandArrayParams(params: Record<string, unknown>): Record<string, unknown> {
+  const expanded: Record<string, unknown> = { ...params };
+
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => {
+        expanded[`${key}_${index}`] = item;
+      });
+    }
+  }
+
+  return expanded;
+}
+
+/**
  * Generate SQL from a query builder function
  * @param queryBuilder Function that builds the query using LINQ operations, optionally with helpers
  * @param params Parameters to pass to the query builder
@@ -45,32 +63,14 @@ export function selectStatement<TParams, TResult>(
   // User params take priority over auto-params to avoid collisions
   const mergedParams = { ...parseResult.autoParams, ...params };
 
-  // Process array indexing in parameters
-  // Look for parameters like "roles[0]" and resolve them
-  const processedParams: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(mergedParams)) {
-    const arrayMatch = key.match(/^(\w+)\[(\d+)\]$/);
-    if (arrayMatch && arrayMatch[1] && arrayMatch[2]) {
-      const arrayName = arrayMatch[1];
-      const index = parseInt(arrayMatch[2], 10);
-      if (arrayName in mergedParams) {
-        const arrayValue = mergedParams[arrayName];
-        if (Array.isArray(arrayValue) && index < arrayValue.length) {
-          processedParams[key] = arrayValue[index];
-        }
-      }
-    } else {
-      processedParams[key] = value;
-    }
-  }
-
   // Generate SQL from the operation tree
   const sql = generateSql(parseResult.operation, mergedParams);
 
-  // Return SQL with processed params (Better SQLite3 will handle parameter substitution)
-  // Include both processed and original params
-  const finalParams = { ...mergedParams, ...processedParams } as TParams &
+  // Expand array parameters into indexed parameters for IN clause support
+  // e.g., { ids: [1, 2, 3] } becomes { ids: [1, 2, 3], "ids[0]": 1, "ids[1]": 2, "ids[2]": 3 }
+  const finalParams = expandArrayParams(mergedParams) as TParams &
     Record<string, string | number | boolean | null>;
+
   return { sql, params: finalParams };
 }
 
@@ -316,9 +316,13 @@ export function insertStatement<TParams, TTable, TReturning = never>(
   const mergedParams = { ...parseResult.autoParams, ...params };
   const sql = generateSql(parseResult.operation, mergedParams);
 
+  // Expand array parameters into indexed parameters for IN clause support
+  const finalParams = expandArrayParams(mergedParams) as TParams &
+    Record<string, string | number | boolean | null>;
+
   return {
     sql,
-    params: mergedParams as TParams & Record<string, string | number | boolean | null>,
+    params: finalParams,
   };
 }
 
@@ -392,9 +396,13 @@ export function updateStatement<TParams, TTable, TReturning = never>(
   const mergedParams = { ...parseResult.autoParams, ...params };
   const sql = generateSql(parseResult.operation, mergedParams);
 
+  // Expand array parameters into indexed parameters for IN clause support
+  const finalParams = expandArrayParams(mergedParams) as TParams &
+    Record<string, string | number | boolean | null>;
+
   return {
     sql,
-    params: mergedParams as TParams & Record<string, string | number | boolean | null>,
+    params: finalParams,
   };
 }
 
@@ -462,9 +470,13 @@ export function deleteStatement<TParams, TResult>(
   const mergedParams = { ...parseResult.autoParams, ...params };
   const sql = generateSql(parseResult.operation, mergedParams);
 
+  // Expand array parameters into indexed parameters for IN clause support
+  const finalParams = expandArrayParams(mergedParams) as TParams &
+    Record<string, string | number | boolean | null>;
+
   return {
     sql,
-    params: mergedParams as TParams & Record<string, string | number | boolean | null>,
+    params: finalParams,
   };
 }
 

--- a/packages/tinqer-sql-better-sqlite3/src/types.ts
+++ b/packages/tinqer-sql-better-sqlite3/src/types.ts
@@ -44,7 +44,7 @@ export interface SqlContext {
   currentShape?: unknown; // The current shape of the query result (after JOINs)
   currentAlias?: string; // Current table alias for resolving column references
   hasJoins?: boolean; // Indicates if the query has JOIN operations
-  params: Record<string, unknown>; // Parameters object for array expansion
+  params?: Record<string, unknown>; // Runtime parameter values for array expansion
 }
 
 /**

--- a/packages/tinqer-sql-better-sqlite3/tests/where-complex.test.ts
+++ b/packages/tinqer-sql-better-sqlite3/tests/where-complex.test.ts
@@ -349,6 +349,8 @@ describe("Complex WHERE Clause SQL Generation", () => {
         maxAge: 55,
         roles: ["admin", "manager"],
         isActive: true,
+        roles_0: "admin",
+        roles_1: "manager",
       });
     });
 

--- a/packages/tinqer-sql-pg-promise-integration/package.json
+++ b/packages/tinqer-sql-pg-promise-integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer-sql-pg-promise-integration",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "description": "PostgreSQL integration tests for Tinqer using pg-promise",
   "type": "module",
   "private": true,

--- a/packages/tinqer-sql-pg-promise-integration/tests/complex-where.test.ts
+++ b/packages/tinqer-sql-pg-promise-integration/tests/complex-where.test.ts
@@ -242,8 +242,16 @@ describe("PostgreSQL Integration - Complex WHERE", () => {
       );
 
       expect(capturedSql).to.exist;
-      expect(capturedSql!.sql).to.equal('SELECT * FROM "users" WHERE "id" = ANY($(targetIds))');
-      expect(capturedSql!.params).to.deep.equal({ targetIds: [1, 3, 5, 7] });
+      expect(capturedSql!.sql).to.equal(
+        'SELECT * FROM "users" WHERE "id" IN ($(targetIds_0), $(targetIds_1), $(targetIds_2), $(targetIds_3))',
+      );
+      expect(capturedSql!.params).to.deep.equal({
+        targetIds: [1, 3, 5, 7],
+        targetIds_0: 1,
+        targetIds_1: 3,
+        targetIds_2: 5,
+        targetIds_3: 7,
+      });
 
       expect(results).to.be.an("array");
       expect(results.length).to.equal(4);
@@ -272,10 +280,12 @@ describe("PostgreSQL Integration - Complex WHERE", () => {
 
       expect(capturedSql).to.exist;
       expect(capturedSql!.sql).to.equal(
-        'SELECT * FROM "products" WHERE ("category" IS NOT NULL AND "category" <> ALL($(excludedCategories)))',
+        'SELECT * FROM "products" WHERE ("category" IS NOT NULL AND "category" NOT IN ($(excludedCategories_0), $(excludedCategories_1)))',
       );
       expect(capturedSql!.params).to.deep.equal({
         excludedCategories: ["Furniture", "Stationery"],
+        excludedCategories_0: "Furniture",
+        excludedCategories_1: "Stationery",
       });
 
       expect(results).to.be.an("array");
@@ -301,7 +311,7 @@ describe("PostgreSQL Integration - Complex WHERE", () => {
       );
 
       expect(capturedSql).to.exist;
-      expect(capturedSql!.sql).to.equal('SELECT * FROM "users" WHERE "id" = ANY($(emptyList))');
+      expect(capturedSql!.sql).to.equal('SELECT * FROM "users" WHERE FALSE');
       expect(capturedSql!.params).to.deep.equal({ emptyList: [] });
 
       expect(results).to.be.an("array");

--- a/packages/tinqer-sql-pg-promise/package.json
+++ b/packages/tinqer-sql-pg-promise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer-sql-pg-promise",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "pg-promise SQL generator for Tinqer query builder",
   "type": "module",
   "main": "./dist/index.js",
@@ -19,7 +19,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@webpods/tinqer": "^0.0.4"
+    "@webpods/tinqer": "^0.0.5"
   },
   "devDependencies": {
     "@types/chai": "5.2.2",

--- a/packages/tinqer-sql-pg-promise/src/sql-generator.ts
+++ b/packages/tinqer-sql-pg-promise/src/sql-generator.ts
@@ -57,11 +57,12 @@ import { generateDelete } from "./generators/delete.js";
 /**
  * Generate SQL from a QueryOperation tree
  */
-export function generateSql(operation: QueryOperation, _params: unknown): string {
+export function generateSql(operation: QueryOperation, params: unknown): string {
   const context: SqlContext = {
     tableAliases: new Map(),
     aliasCounter: 0,
     formatParameter: (paramName: string) => `$(${paramName})`, // pg-promise format
+    params: params as Record<string, unknown>,
   };
 
   // Collect all operations in the chain

--- a/packages/tinqer-sql-pg-promise/src/types.ts
+++ b/packages/tinqer-sql-pg-promise/src/types.ts
@@ -44,6 +44,7 @@ export interface SqlContext {
   currentShape?: unknown; // The current shape of the query result (after JOINs)
   currentAlias?: string; // Current table alias for resolving column references
   hasJoins?: boolean; // Indicates if the query has JOIN operations
+  params?: Record<string, unknown>; // Runtime parameter values for array expansion
 }
 
 /**

--- a/packages/tinqer-sql-pg-promise/tests/delete-statement.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/delete-statement.test.ts
@@ -243,9 +243,12 @@ describe("DELETE Statement Generation", () => {
         { ids: [4, 5, 6] },
       );
 
-      assert.equal(result.sql, `DELETE FROM "users" WHERE "id" = ANY($(ids))`);
+      assert.equal(result.sql, `DELETE FROM "users" WHERE "id" IN ($(ids_0), $(ids_1), $(ids_2))`);
       assert.deepEqual(result.params, {
         ids: [4, 5, 6],
+        ids_0: 4,
+        ids_1: 5,
+        ids_2: 6,
       });
     });
   });

--- a/packages/tinqer-sql-pg-promise/tests/where-complex.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/where-complex.test.ts
@@ -346,6 +346,8 @@ describe("Complex WHERE Clause SQL Generation", () => {
         maxAge: 55,
         roles: ["admin", "manager"],
         isActive: true,
+        roles_0: "admin",
+        roles_1: "manager",
       });
     });
 

--- a/packages/tinqer/package.json
+++ b/packages/tinqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "LINQ to SQL for TypeScript",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
- Fixed pg-promise type inference issues where array parameters were formatted as text arrays instead of properly typed values
- Changed from ANY()/ALL() syntax to standard IN/NOT IN clause
- Array parameters now expand to indexed parameters (e.g., ids -> ids_0, ids_1)
- Applied fix to both pg-promise and better-sqlite3 adapters
- Updated all integration and unit tests for new parameter format
- Bumped all package versions to 0.0.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)