### PR TITLE
docs: update ARCHITECTURE.md to remove ExistsExpression reference

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,8 +47,7 @@ export type BooleanExpression =
   | BooleanMemberExpression // x.isActive
   | BooleanMethodExpression // x.name.startsWith("J")
   | NotExpression // !x.isDeleted
-  | BooleanConstantExpression // true or false
-  | ExistsExpression; // EXISTS (subquery)
+  | BooleanConstantExpression; // true or false
 
 // Value expressions - evaluate to a value
 export type ValueExpression =


### PR DESCRIPTION
Remove outdated reference to ExistsExpression in BooleanExpression type union example. This placeholder type was removed in previous commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)