### PR TITLE
fix: bump all packages to 0.0.10 with correct peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4461,7 +4461,7 @@
     },
     "packages/tinqer": {
       "name": "@webpods/tinqer",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MIT",
       "dependencies": {
         "oxc-parser": "^0.90.0"
@@ -4502,7 +4502,7 @@
     },
     "packages/tinqer-sql-better-sqlite3": {
       "name": "@webpods/tinqer-sql-better-sqlite3",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MIT",
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",
@@ -4515,12 +4515,12 @@
         "typescript": "5.9.2"
       },
       "peerDependencies": {
-        "@webpods/tinqer": "^0.0.8"
+        "@webpods/tinqer": "^0.0.10"
       }
     },
     "packages/tinqer-sql-better-sqlite3-integration": {
       "name": "@webpods/tinqer-sql-better-sqlite3-integration",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "dependencies": {
         "@webpods/tinqer": "file:../tinqer",
         "@webpods/tinqer-sql-better-sqlite3": "file:../tinqer-sql-better-sqlite3",
@@ -4539,7 +4539,7 @@
     },
     "packages/tinqer-sql-pg-promise": {
       "name": "@webpods/tinqer-sql-pg-promise",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "5.2.2",
@@ -4552,12 +4552,12 @@
         "typescript": "5.9.2"
       },
       "peerDependencies": {
-        "@webpods/tinqer": "^0.0.8"
+        "@webpods/tinqer": "^0.0.10"
       }
     },
     "packages/tinqer-sql-pg-promise-integration": {
       "name": "@webpods/tinqer-sql-pg-promise-integration",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "dependencies": {
         "@webpods/tinqer": "file:../tinqer",
         "@webpods/tinqer-sql-pg-promise": "file:../tinqer-sql-pg-promise",

--- a/packages/tinqer-sql-better-sqlite3-integration/package.json
+++ b/packages/tinqer-sql-better-sqlite3-integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer-sql-better-sqlite3-integration",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": true,
   "type": "module",
   "description": "SQLite integration tests for Tinqer using better-sqlite3",

--- a/packages/tinqer-sql-better-sqlite3-integration/tests/window-functions.test.ts
+++ b/packages/tinqer-sql-better-sqlite3-integration/tests/window-functions.test.ts
@@ -816,5 +816,29 @@ describe("Window Functions - SQLite Integration", () => {
         expect(row.rn4).to.be.at.most(2);
       });
     });
+
+    it("should handle COUNT after window filter", () => {
+      const count = executeSelect(
+        db,
+        (_, h) =>
+          from(dbContext, "users")
+            .select((u) => ({
+              id: u.id,
+              name: u.name,
+              department_id: u.department_id,
+              rn: h
+                .window(u)
+                .partitionBy((r) => r.department_id)
+                .orderByDescending((r) => r.salary)
+                .rowNumber(),
+            }))
+            .where((r) => r.rn === 1 && r.department_id !== null)
+            .count(),
+        {},
+      );
+
+      // Should count top earner from each department
+      expect(count).to.equal(4); // 4 departments
+    });
   });
 });

--- a/packages/tinqer-sql-better-sqlite3/package.json
+++ b/packages/tinqer-sql-better-sqlite3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer-sql-better-sqlite3",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Better SQLite3 SQL generator for Tinqer query builder",
   "type": "module",
   "main": "./dist/index.js",
@@ -19,7 +19,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@webpods/tinqer": "^0.0.8"
+    "@webpods/tinqer": "^0.0.10"
   },
   "devDependencies": {
     "@types/chai": "5.2.2",

--- a/packages/tinqer-sql-pg-promise-integration/package.json
+++ b/packages/tinqer-sql-pg-promise-integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer-sql-pg-promise-integration",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "PostgreSQL integration tests for Tinqer using pg-promise",
   "type": "module",
   "private": true,

--- a/packages/tinqer-sql-pg-promise-integration/tests/window-functions.test.ts
+++ b/packages/tinqer-sql-pg-promise-integration/tests/window-functions.test.ts
@@ -820,5 +820,29 @@ describe("Window Functions - PostgreSQL Integration", () => {
         expect(row.rn4).to.be.at.most(2);
       });
     });
+
+    it("should handle COUNT after window filter", async () => {
+      const count = await executeSelect(
+        db,
+        (_, h) =>
+          from(dbContext, "users")
+            .select((u) => ({
+              id: u.id,
+              name: u.name,
+              department_id: u.department_id,
+              rn: h
+                .window(u)
+                .partitionBy((r) => r.department_id)
+                .orderByDescending((r) => r.salary)
+                .rowNumber(),
+            }))
+            .where((r) => r.rn === 1 && r.department_id !== null)
+            .count(),
+        {},
+      );
+
+      // Should count top earner from each department
+      expect(count).to.equal(4); // 4 departments
+    });
   });
 });

--- a/packages/tinqer-sql-pg-promise/package.json
+++ b/packages/tinqer-sql-pg-promise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer-sql-pg-promise",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "pg-promise SQL generator for Tinqer query builder",
   "type": "module",
   "main": "./dist/index.js",
@@ -19,7 +19,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@webpods/tinqer": "^0.0.8"
+    "@webpods/tinqer": "^0.0.10"
   },
   "devDependencies": {
     "@types/chai": "5.2.2",

--- a/packages/tinqer-sql-pg-promise/tests/window-functions.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/window-functions.test.ts
@@ -344,5 +344,29 @@ describe("Window Functions - PostgreSQL", () => {
       // Regular filter should be in innermost query
       expect(result.sql).to.include("$(__p1)");
     });
+
+    it("should handle COUNT after window filter", () => {
+      const result = selectStatement(
+        (_, h) =>
+          from(db, "users")
+            .select((u) => ({
+              id: u.id,
+              name: u.name,
+              rn: h
+                .window(u)
+                .partitionBy((r) => r.department)
+                .orderByDescending((r) => r.salary)
+                .rowNumber(),
+            }))
+            .where((u) => u.rn === 1)
+            .count(),
+        { __p1: 1 },
+      );
+
+      // Should wrap in subquery and then COUNT
+      expect(result.sql).to.include("SELECT COUNT(*) FROM (");
+      expect(result.sql).to.include("ROW_NUMBER() OVER");
+      expect(result.sql).to.include('WHERE "rn" = $(__p1)');
+    });
   });
 });

--- a/packages/tinqer/package.json
+++ b/packages/tinqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "LINQ to SQL for TypeScript",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
All packages now at version 0.0.10 with matching peerDependencies.

Changes:
- @webpods/tinqer: 0.0.9 → 0.0.10
- @webpods/tinqer-sql-pg-promise: 0.0.9 → 0.0.10
- @webpods/tinqer-sql-better-sqlite3: 0.0.9 → 0.0.10
- @webpods/tinqer-sql-pg-promise-integration: 0.0.9 → 0.0.10
- @webpods/tinqer-sql-better-sqlite3-integration: 0.0.9 → 0.0.10

- Updated peerDependencies: ^0.0.8 → ^0.0.10

All packages synchronized at 0.0.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)