### PR TITLE
refactor: standardize helpers parameter naming to 'h'

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -80,8 +80,7 @@ const results = executeSelect(
     q
       .from("products")
       .where((p) => p.inStock === 1 && p.price < params.maxPrice)
-      .orderByDescending((p) => p.price)
-      .select((p) => p),
+      .orderByDescending((p) => p.price),
   { maxPrice: 100 },
 );
 
@@ -209,7 +208,7 @@ Window functions enable calculations across rows related to the current row. Tin
 const topEarners = await executeSelect(
   db,
   schema,
-  (q, _params, h) =>
+  (q, h) =>
     q
       .from("employees")
       .select((e) => ({
@@ -221,7 +220,6 @@ const topEarners = await executeSelect(
           .rowNumber(),
       }))
       .where((e) => e.rank === 1), // Filtering on window function result
-  {},
 );
 
 // Generated SQL (automatically wrapped):
@@ -248,7 +246,7 @@ const schema = createSchema<Schema>();
 const insertedRows = await executeInsert(
   db,
   schema,
-  (q, ) =>
+  (q) =>
     q.insertInto("users").values({
       name: "Alice",
       email: "alice@example.com",
@@ -273,7 +271,7 @@ const inactiveUsers = await executeUpdate(
 const deletedCount = await executeDelete(
   db,
   schema,
-  (q, ) => q.deleteFrom("users").where((u) => u.status === "deleted"),
+  (q) => q.deleteFrom("users").where((u) => u.status === "deleted"),
   {},
 );
 
@@ -288,28 +286,14 @@ All literal values are automatically parameterized to prevent SQL injection:
 // External parameters via params object
 const schema = createSchema<Schema>();
 
-const sample = selectStatement(
-  schema,
-  (q, p) =>
-    q
-      .from("users")
-      .where((u) => u.age >= p.minAge)
-      .select((u) => u),
-  { minAge: 18 },
-);
+const sample = selectStatement(schema, (q, p) => q.from("users").where((u) => u.age >= p.minAge), {
+  minAge: 18,
+});
 // SQL (PostgreSQL): SELECT * FROM "users" WHERE "age" >= $(minAge)
 // params: { minAge: 18 }
 
 // Literals auto-parameterized automatically
-const literals = selectStatement(
-  schema,
-  (q) =>
-    q
-      .from("users")
-      .where((u) => u.age >= 18)
-      .select((u) => u),
-  {},
-);
+const literals = selectStatement(schema, (q) => q.from("users").where((u) => u.age >= 18), {});
 // params: { __p1: 18 }
 ```
 
@@ -320,11 +304,8 @@ import { createSchema } from "@webpods/tinqer";
 
 const schema = createSchema<Schema>();
 
-const query = (q, _params, helpers) =>
-  q
-    .from("users")
-    .where((u) => helpers.contains(u.name, "alice")) // Case-insensitive substring match
-    .select((u) => u);
+const query = (q, params, helpers) =>
+  q.from("users").where((u) => helpers.contains(u.name, "alice")); // Case-insensitive substring match
 
 // PostgreSQL: WHERE u.name ILIKE $1 (param: "%alice%")
 // SQLite: WHERE LOWER(u.name) LIKE LOWER(?) (param: "%alice%")
@@ -567,8 +548,7 @@ db.exec(`
 const inserted = executeInsert(
   db,
   schema,
-  (q) =>
-    q.insertInto("users").values({ name: "Sam", email: "sam@example.com", age: 28 }),
+  (q) => q.insertInto("users").values({ name: "Sam", email: "sam@example.com", age: 28 }),
   {},
 );
 // inserted === 1
@@ -656,7 +636,7 @@ const schema = createSchema<Schema>();
 
 const { sql } = selectStatement(
   schema,
-  (q, _params, helpers) =>
+  (q, params, helpers) =>
     q.from("users").where((u) => helpers.functions.icontains(u.name, "alice")),
   {},
 );
@@ -1120,7 +1100,7 @@ const schema = createSchema<Schema>();
 
 const result = selectStatement(
   schema,
-  (q, _params, helpers) =>
+  (q, params, helpers) =>
     q.from("users").where((u) => helpers.functions.icontains(u.name, "alice")),
   {},
 );
@@ -1337,12 +1317,7 @@ describe("SQL Generation", () => {
     }
 
     const schema = createSchema<Schema>();
-    const result = selectStatement(schema, (q) =>
-      q
-        .from("users")
-        .where((u) => u.age >= 18)
-        .select((u) => u),
-    );
+    const result = selectStatement(schema, (q) => q.from("users").where((u) => u.age >= 18));
 
     // Assert SQL and parameters
     assert.ok(result.sql.includes("WHERE"));
@@ -1812,7 +1787,7 @@ interface Schema {
 
 const schema = createSchema<Schema>();
 
-const adults = selectStatement(schema, (ctx) => ctx.from("users").where((u) => u.age >= 18), {});
+const adults = selectStatement(schema, (q) => ctx.from("users").where((u) => u.age >= 18), {});
 ```
 
 ```sql
@@ -1834,7 +1809,7 @@ SELECT * FROM "users" WHERE "age" >= @__p1
 ```typescript
 const activeRange = selectStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .from("users")
       .where((u) => u.age >= 21)
@@ -1865,7 +1840,7 @@ WHERE "age" >= @__p1 AND "age" <= @__p2 AND "active" = @__p3
 ```typescript
 const premium = selectStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx.from("users").where((u) => (u.salary * 0.9 > 150_000 && u.age < 55) || u.active === false),
   {},
 );
@@ -1892,7 +1867,7 @@ WHERE ((("salary" * @__p1) > @__p2 AND "age" < @__p3) OR "active" = @__p4)
 ```typescript
 const preferredName = selectStatement(
   schema,
-  (ctx) => ctx.from("users").where((u) => (u.nickname ?? u.name) === "anonymous"),
+  (q) => ctx.from("users").where((u) => (u.nickname ?? u.name) === "anonymous"),
   {},
 );
 ```
@@ -1916,7 +1891,7 @@ SELECT * FROM "users" WHERE COALESCE("nickname", "name") = @__p1
 ```typescript
 const emailFilters = selectStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .from("users")
       .where((u) => u.email.startsWith("admin"))
@@ -1951,7 +1926,7 @@ WHERE "email" LIKE @__p1 || '%'
 ```typescript
 const insensitive = selectStatement(
   schema,
-  (q, _params, helpers) => q.from("users").where((u) => helpers.functions.iequals(u.name, "ALICE")),
+  (q, params, helpers) => q.from("users").where((u) => helpers.functions.iequals(u.name, "ALICE")),
   {},
 );
 ```
@@ -1975,7 +1950,7 @@ SELECT * FROM "users" WHERE LOWER("name") = LOWER(@__p1)
 ```typescript
 const allowed = selectStatement(
   schema,
-  (ctx) => ctx.from("users").where((u) => ["admin", "support", "auditor"].includes(u.role)),
+  (q) => ctx.from("users").where((u) => ["admin", "support", "auditor"].includes(u.role)),
   {},
 );
 ```
@@ -2046,7 +2021,7 @@ The `select` method transforms query results by projecting columns or computed e
 ### 2.1 Full Row Projection
 
 ```typescript
-const fullRow = selectStatement(schema, (ctx) => ctx.from("users").select((u) => u), {});
+const fullRow = selectStatement(schema, (q) => q.from("users"), {});
 ```
 
 ```sql
@@ -2064,7 +2039,7 @@ SELECT * FROM "users"
 ```typescript
 const summary = selectStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .from("users")
       .where((u) => u.active)
@@ -2099,7 +2074,7 @@ const productContext = createSchema<ProductSchema>();
 
 const pricing = selectStatement(
   productContext,
-  (ctx) =>
+  (q) =>
     ctx.from("products").select((p) => ({
       id: p.id,
       name: p.name,
@@ -2132,7 +2107,7 @@ Methods `orderBy`, `orderByDescending`, `thenBy`, and `thenByDescending` control
 ### 3.1 Single Key Ascending
 
 ```typescript
-const alphabetical = selectStatement(schema, (ctx) => ctx.from("users").orderBy((u) => u.name), {});
+const alphabetical = selectStatement(schema, (q) => ctx.from("users").orderBy((u) => u.name), {});
 ```
 
 ```sql
@@ -2150,7 +2125,7 @@ SELECT * FROM "users" ORDER BY "name" ASC
 ```typescript
 const ordered = selectStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .from("users")
       .orderBy((u) => u.departmentId)
@@ -2177,7 +2152,7 @@ SELECT * FROM "users" ORDER BY "departmentId" ASC, "salary" DESC, "name" ASC
 ```typescript
 const departments = selectStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .from("users")
       .select((u) => u.departmentId)
@@ -2207,7 +2182,7 @@ Methods `skip` and `take` implement OFFSET and LIMIT clauses.
 ```typescript
 const page = selectStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .from("users")
       .orderBy((u) => u.id)
@@ -2236,7 +2211,7 @@ SELECT * FROM "users" ORDER BY "id" ASC LIMIT @__p2 OFFSET @__p1
 ```typescript
 const filteredPage = selectStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .from("users")
       .where((u) => u.active)
@@ -2278,7 +2253,7 @@ const joinContext = createSchema<JoinSchema>();
 
 const userDepartments = selectStatement(
   joinContext,
-  (ctx) =>
+  (q) =>
     ctx.from("users").join(
       ctx.from("departments"),
       (u) => u.departmentId,
@@ -2314,7 +2289,7 @@ const orderContext = createSchema<OrderSchema>();
 
 const regionOrders = selectStatement(
   orderContext,
-  (ctx) =>
+  (q) =>
     ctx
       .from("users")
       .where((u) => u.id > 100)
@@ -2354,7 +2329,7 @@ WHERE "t0"."id" > @__p1 AND "t1"."total" > @__p2
 ```typescript
 const totalsByDepartment = selectStatement(
   orderContext,
-  (ctx) =>
+  (q) =>
     ctx
       .from("users")
       .join(
@@ -2396,7 +2371,7 @@ Model the classic LINQ pattern: start with `groupJoin`, then expand the grouped 
 ```typescript
 const usersWithDepartments = selectStatement(
   joinContext,
-  (ctx) =>
+  (q) =>
     ctx
       .from("users")
       .groupJoin(
@@ -2438,7 +2413,7 @@ Return a `Queryable` from the collection selector passed to `selectMany`. Becaus
 ```typescript
 const departmentUsers = selectStatement(
   joinContext,
-  (ctx) =>
+  (q) =>
     ctx
       .from("departments")
       .selectMany(
@@ -2480,7 +2455,7 @@ The `groupBy` method groups results and enables aggregate functions: `count`, `s
 ```typescript
 const byDepartment = selectStatement(
   schema,
-  (ctx) => ctx.from("users").groupBy((u) => u.departmentId),
+  (q) => ctx.from("users").groupBy((u) => u.departmentId),
   {},
 );
 ```
@@ -2500,7 +2475,7 @@ SELECT "departmentId" FROM "users" GROUP BY "departmentId"
 ```typescript
 const departmentStats = selectStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .from("users")
       .groupBy((u) => u.departmentId)
@@ -2538,7 +2513,7 @@ ORDER BY "totalSalary" DESC
 const largeDepartments = await executeSelect(
   db,
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .from("users")
       .groupBy((u) => u.departmentId)
@@ -2574,7 +2549,7 @@ const empContext = createSchema<EmployeeSchema>();
 
 const rankedEmployees = selectStatement(
   empContext,
-  (q, _params, helpers) =>
+  (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
       department: e.department,
@@ -2613,7 +2588,7 @@ const orderTimeContext = createSchema<OrderTimeSchema>();
 
 const chronological = selectStatement(
   orderTimeContext,
-  (q, _params, helpers) =>
+  (q, params, helpers) =>
     q.from("orders").select((o) => ({
       orderId: o.id,
       rowNum: helpers
@@ -2641,7 +2616,7 @@ const regionEmpContext = createSchema<RegionEmployeeSchema>();
 
 const multiPartition = selectStatement(
   regionEmpContext,
-  (q, _params, helpers) =>
+  (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
       rank: helpers
@@ -2669,7 +2644,7 @@ FROM "employees"
 ```typescript
 const ranked = selectStatement(
   empContext,
-  (q, _params, helpers) =>
+  (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
       rank: helpers
@@ -2697,7 +2672,7 @@ FROM "employees"
 ```typescript
 const rankedSalaries = selectStatement(
   empContext,
-  (q, _params, helpers) =>
+  (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
       salary: e.salary,
@@ -2745,7 +2720,7 @@ const playerContext = createSchema<PlayerSchema>();
 
 const globalRank = selectStatement(
   playerContext,
-  (q, _params, helpers) =>
+  (q, params, helpers) =>
     q.from("players").select((p) => ({
       player: p.name,
       score: p.score,
@@ -2771,7 +2746,7 @@ FROM "players"
 ```typescript
 const denseRanked = selectStatement(
   empContext,
-  (q, _params, helpers) =>
+  (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
       salary: e.salary,
@@ -2817,7 +2792,7 @@ const empAgeContext = createSchema<EmployeeAgeSchema>();
 
 const complexRanking = selectStatement(
   empAgeContext,
-  (q, _params, helpers) =>
+  (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
       rank: helpers
@@ -2849,7 +2824,7 @@ Combine multiple window functions in a single SELECT:
 ```typescript
 const allRankings = selectStatement(
   empContext,
-  (q, _params, helpers) =>
+  (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
       department: e.department,
@@ -2904,7 +2879,7 @@ Get the top earner from each department:
 const topEarners = await executeSelect(
   db,
   empContext,
-  (q, _params, helpers) =>
+  (q, params, helpers) =>
     q
       .from("employees")
       .select((e) => ({
@@ -2996,7 +2971,7 @@ const perfContext = createSchema<PerformanceSchema>();
 const topPerformers = await executeSelect(
   db,
   perfContext,
-  (q, _params, helpers) =>
+  (q, params, helpers) =>
     q
       .from("employees")
       .select((e) => ({
@@ -3033,7 +3008,7 @@ const activeEmpContext = createSchema<ActiveEmployeeSchema>();
 const activeTopEarners = await executeSelect(
   db,
   activeEmpContext,
-  (q, _params, helpers) =>
+  (q, params, helpers) =>
     q
       .from("employees")
       .select((e) => ({
@@ -3078,7 +3053,7 @@ Aggregate methods can be called directly on queries to return single values.
 ```typescript
 const totals = selectStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .from("users")
       .where((u) => u.active === true)
@@ -3104,7 +3079,7 @@ SELECT SUM("salary") FROM "users" WHERE "active" = @__p1
 Methods `count`, `average`, `min`, and `max` follow the same structure. The `count` method also accepts a predicate:
 
 ```typescript
-const activeCount = selectStatement(schema, (ctx) => ctx.from("users").count((u) => u.active), {});
+const activeCount = selectStatement(schema, (q) => ctx.from("users").count((u) => u.active), {});
 ```
 
 ```sql
@@ -3126,7 +3101,7 @@ Methods `any` and `all` test whether elements satisfy conditions.
 ### 10.1 Any Operation
 
 ```typescript
-const hasAdults = selectStatement(schema, (ctx) => ctx.from("users").any((u) => u.age >= 18), {});
+const hasAdults = selectStatement(schema, (q) => ctx.from("users").any((u) => u.age >= 18), {});
 ```
 
 ```sql
@@ -3150,7 +3125,7 @@ The `all` method emits a `NOT EXISTS` check:
 ```typescript
 const allActive = selectStatement(
   schema,
-  (ctx) => ctx.from("users").all((u) => u.active === true),
+  (q) => ctx.from("users").all((u) => u.active === true),
   {},
 );
 ```
@@ -3174,7 +3149,7 @@ Methods `first`, `firstOrDefault`, `single`, `singleOrDefault`, `last`, and `las
 ```typescript
 const newestUser = selectStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .from("users")
       .orderBy((u) => u.createdAt)
@@ -3207,7 +3182,7 @@ Queries are executed directly without requiring a materialization method. The qu
 const activeUsers = await executeSelect(
   db,
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .from("users")
       .where((u) => u.active)
@@ -3321,7 +3296,7 @@ const dynamicMembership = selectStatement(
 ```typescript
 const ic = selectStatement(
   schema,
-  (q, _params, helpers) =>
+  (q, params, helpers) =>
     q.from("users").where((u) => helpers.functions.icontains(u.email, "support")),
   {},
 );
@@ -3365,7 +3340,7 @@ const schema = createSchema<Schema>();
 // Insert with literal values - direct object syntax
 const insert = insertStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx.insertInto("users").values({
       name: "Alice",
       age: 30,
@@ -3420,7 +3395,7 @@ Both PostgreSQL and SQLite (3.35.0+) support the RETURNING clause to retrieve va
 // Return specific columns
 const insertWithReturn = insertStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .insertInto("users")
       .values({ name: "Charlie", age: 35 })
@@ -3431,7 +3406,7 @@ const insertWithReturn = insertStatement(
 // Return all columns
 const insertReturnAll = insertStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .insertInto("users")
       .values({ name: "David", age: 40 })
@@ -3445,7 +3420,7 @@ const insertReturnAll = insertStatement(
 ```typescript
 const insert = insertStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx.insertInto("users").values({
       name: "Eve",
       email: null, // Generates NULL, not parameterized
@@ -3469,7 +3444,7 @@ const schema = createSchema<Schema>();
 
 const updateStmt = updateStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .update("users")
       .set({ age: 31, lastModified: new Date() })
@@ -3513,7 +3488,7 @@ const updateStmt = updateStatement(
 ```typescript
 const updateStmt = updateStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .update("users")
       .set({ status: "inactive" })
@@ -3527,7 +3502,7 @@ const updateStmt = updateStatement(
 ```typescript
 const updateWithReturn = updateStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .update("users")
       .set({ age: 32 })
@@ -3543,7 +3518,7 @@ const updateWithReturn = updateStatement(
 // UPDATE without WHERE requires explicit permission
 const updateAll = updateStatement(
   schema,
-  (ctx) => ctx.update("users").set({ isActive: true }).allowFullTableUpdate(), // Required flag
+  (q) => ctx.update("users").set({ isActive: true }).allowFullTableUpdate(), // Required flag
   {},
 );
 ```
@@ -3567,7 +3542,7 @@ import { deleteStatement } from "@webpods/tinqer-sql-pg-promise";
 
 const schema = createSchema<Schema>();
 
-const del = deleteStatement(schema, (ctx) => ctx.deleteFrom("users").where((u) => u.age > 100), {});
+const del = deleteStatement(schema, (q) => ctx.deleteFrom("users").where((u) => u.age > 100), {});
 ```
 
 Generated SQL:
@@ -3582,7 +3557,7 @@ DELETE FROM "users" WHERE "age" > @__p1    -- SQLite
 ```typescript
 const del = deleteStatement(
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .deleteFrom("users")
       .where((u) => u.isDeleted === true || (u.age < 18 && u.role !== "admin") || u.email === null),
@@ -3629,7 +3604,7 @@ WHERE "id" IN (@userIds_0, @userIds_1, @userIds_2, @userIds_3, @userIds_4)
 // DELETE without WHERE requires explicit permission
 const deleteAll = deleteStatement(
   schema,
-  (ctx) => ctx.deleteFrom("users").allowFullTableDelete(), // Required flag
+  (q) => ctx.deleteFrom("users").allowFullTableDelete(), // Required flag
   {},
 );
 ```
@@ -3644,11 +3619,11 @@ UPDATE and DELETE operations require WHERE clauses by default to prevent acciden
 
 ```typescript
 // This throws an error
-deleteStatement(schema, (ctx) => ctx.deleteFrom("users"), {});
+deleteStatement(schema, (q) => ctx.deleteFrom("users"), {});
 // Error: DELETE requires a WHERE clause or explicit allowFullTableDelete()
 
 // This works
-deleteStatement(schema, (ctx) => ctx.deleteFrom("users").allowFullTableDelete(), {});
+deleteStatement(schema, (q) => ctx.deleteFrom("users").allowFullTableDelete(), {});
 ```
 
 #### Type Safety
@@ -3664,7 +3639,7 @@ const userContext = createSchema<UserSchema>();
 // Type error: 'username' doesn't exist on users table
 insertStatement(
   userContext,
-  (ctx) =>
+  (q) =>
     ctx.insertInto("users").values({
       username: "Alice", // ❌ Type error
     }),
@@ -3674,7 +3649,7 @@ insertStatement(
 // Type error: age must be number
 updateStatement(
   userContext,
-  (ctx) =>
+  (q) =>
     ctx.update("users").set({
       age: "30", // ❌ Type error - must be number
     }),
@@ -3690,7 +3665,7 @@ All values are automatically parameterized to prevent SQL injection:
 const maliciousName = "'; DROP TABLE users; --";
 const insert = insertStatement(
   userContext,
-  (ctx) =>
+  (q) =>
     ctx.insertInto("users").values({
       name: maliciousName, // Safely parameterized
     }),
@@ -3713,7 +3688,7 @@ import { executeInsert, executeUpdate, executeDelete } from "@webpods/tinqer-sql
 const insertedUsers = await executeInsert(
   db,
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .insertInto("users")
       .values({ name: "Frank", age: 28 })
@@ -3726,7 +3701,7 @@ const insertedUsers = await executeInsert(
 const updateCount = await executeUpdate(
   db,
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .update("users")
       .set({ age: 29 })
@@ -3739,7 +3714,7 @@ const updateCount = await executeUpdate(
 const deleteCount = await executeDelete(
   db,
   schema,
-  (ctx) => ctx.deleteFrom("users").where((u) => u.id === 123),
+  (q) => ctx.deleteFrom("users").where((u) => u.id === 123),
   {},
 );
 ```
@@ -3753,7 +3728,7 @@ import { executeInsert, executeUpdate, executeDelete } from "@webpods/tinqer-sql
 const insertCount = executeInsert(
   db,
   schema,
-  (ctx) => ctx.insertInto("users").values({ name: "Grace", age: 30 }),
+  (q) => ctx.insertInto("users").values({ name: "Grace", age: 30 }),
   {},
 );
 // Returns number of inserted rows
@@ -3762,7 +3737,7 @@ const insertCount = executeInsert(
 const updateCount = executeUpdate(
   db,
   schema,
-  (ctx) =>
+  (q) =>
     ctx
       .update("users")
       .set({ age: 33 })
@@ -3774,7 +3749,7 @@ const updateCount = executeUpdate(
 const deleteCount = executeDelete(
   db,
   schema,
-  (ctx) => ctx.deleteFrom("users").where((u) => u.age > 100),
+  (q) => ctx.deleteFrom("users").where((u) => u.age > 100),
   {},
 );
 ```
@@ -3797,7 +3772,7 @@ await db.tx(async (t) => {
   const users = await executeInsert(
     t,
     txContext,
-    (ctx) =>
+    (q) =>
       ctx
         .insertInto("users")
         .values({ name: "Ivy" })
@@ -3808,7 +3783,7 @@ await db.tx(async (t) => {
   await executeInsert(
     t,
     txContext,
-    (ctx) =>
+    (q) =>
       ctx.insertInto("user_logs").values({
         userId: users[0]!.id,
         action: "created",
@@ -3819,11 +3794,11 @@ await db.tx(async (t) => {
 
 // SQLite transactions
 const transaction = sqliteDb.transaction(() => {
-  executeInsert(db, txContext, (ctx) => ctx.insertInto("users").values({ name: "Jack" }), {});
+  executeInsert(db, txContext, (q) => ctx.insertInto("users").values({ name: "Jack" }), {});
   executeUpdate(
     db,
     txContext,
-    (ctx) =>
+    (q) =>
       ctx
         .update("users")
         .set({ lastLogin: new Date() })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer-monorepo",
-  "version": "0.0.11",
+  "version": "0.0.14",
   "description": "LINQ to SQL for TypeScript",
   "type": "module",
   "private": true,

--- a/packages/tinqer-sql-better-sqlite3/package.json
+++ b/packages/tinqer-sql-better-sqlite3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer-sql-better-sqlite3",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Better SQLite3 SQL generator for Tinqer query builder",
   "type": "module",
   "main": "./dist/index.js",
@@ -19,7 +19,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@webpods/tinqer": "^0.0.13"
+    "@webpods/tinqer": "^0.0.14"
   },
   "devDependencies": {
     "@types/chai": "5.2.2",

--- a/packages/tinqer-sql-better-sqlite3/tests/case-insensitive-functions.test.ts
+++ b/packages/tinqer-sql-better-sqlite3/tests/case-insensitive-functions.test.ts
@@ -27,7 +27,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should generate LOWER() = LOWER() for iequals", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => _.functions.iequals(u.name, "John")),
+        (q, _params, h) => q.from("users").where((u) => h.functions.iequals(u.name, "John")),
         { users: [] },
       );
 
@@ -38,7 +38,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle column-to-column comparison", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => _.functions.iequals(u.name, u.email)),
+        (q, _params, h) => q.from("users").where((u) => h.functions.iequals(u.name, u.email)),
         { users: [] },
       );
 
@@ -49,8 +49,8 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle query parameters", () => {
       const result = selectStatement(
         schema,
-        (q, params, _) =>
-          q.from("users").where((u) => _.functions.iequals(u.name, params.searchName)),
+        (q, params, h) =>
+          q.from("users").where((u) => h.functions.iequals(u.name, params.searchName)),
         { users: [], searchName: "Alice" },
       );
 
@@ -63,7 +63,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should generate LOWER() LIKE LOWER() || '%' for istartsWith", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => _.functions.istartsWith(u.name, "J")),
+        (q, _params, h) => q.from("users").where((u) => h.functions.istartsWith(u.name, "J")),
         { users: [] },
       );
 
@@ -76,7 +76,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle complex prefix values", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => _.functions.istartsWith(u.email, "admin@")),
+        (q, _params, h) => q.from("users").where((u) => h.functions.istartsWith(u.email, "admin@")),
         { users: [] },
       );
 
@@ -91,7 +91,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should generate LOWER() LIKE '%' || LOWER() for iendsWith", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => _.functions.iendsWith(u.email, ".com")),
+        (q, _params, h) => q.from("users").where((u) => h.functions.iendsWith(u.email, ".com")),
         { users: [] },
       );
 
@@ -106,7 +106,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should generate LOWER() LIKE '%' || LOWER() || '%' for icontains", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => _.functions.icontains(u.bio!, "developer")),
+        (q, _params, h) => q.from("users").where((u) => h.functions.icontains(u.bio!, "developer")),
         { users: [] },
       );
 
@@ -119,7 +119,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle null-safe navigation", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => _.functions.icontains(u.bio!, "engineer")),
+        (q, _params, h) => q.from("users").where((u) => h.functions.icontains(u.bio!, "engineer")),
         { users: [] },
       );
 
@@ -134,8 +134,8 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle AND conditions", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) =>
-          q.from("users").where((u) => _.functions.iequals(u.name, "John") && u.age > 18),
+        (q, _params, h) =>
+          q.from("users").where((u) => h.functions.iequals(u.name, "John") && u.age > 18),
         { users: [] },
       );
 
@@ -148,11 +148,11 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle OR conditions", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) =>
+        (q, _params, h) =>
           q
             .from("users")
             .where(
-              (u) => _.functions.istartsWith(u.name, "A") || _.functions.istartsWith(u.name, "B"),
+              (u) => h.functions.istartsWith(u.name, "A") || h.functions.istartsWith(u.name, "B"),
             ),
         { users: [] },
       );
@@ -166,10 +166,10 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle mixed case-sensitive and case-insensitive operations", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) =>
+        (q, _params, h) =>
           q
             .from("users")
-            .where((u) => _.functions.icontains(u.email, "admin") && u.email.endsWith(".com")),
+            .where((u) => h.functions.icontains(u.email, "admin") && u.email.endsWith(".com")),
         { users: [] },
       );
 
@@ -182,10 +182,10 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should work with select projection", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) =>
+        (q, _params, h) =>
           q
             .from("users")
-            .where((u) => _.functions.iequals(u.role!, "ADMIN"))
+            .where((u) => h.functions.iequals(u.role!, "ADMIN"))
             .select((u) => ({
               id: u.id,
               name: u.name,
@@ -203,10 +203,10 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should work with orderBy", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) =>
+        (q, _params, h) =>
           q
             .from("users")
-            .where((u) => _.functions.icontains(u.bio!, "software"))
+            .where((u) => h.functions.icontains(u.bio!, "software"))
             .orderBy((u) => u.name),
         { users: [] },
       );
@@ -222,7 +222,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle NOT with iequals", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => !_.functions.iequals(u.role!, "admin")),
+        (q, _params, h) => q.from("users").where((u) => !h.functions.iequals(u.role!, "admin")),
         { users: [] },
       );
 
@@ -233,13 +233,13 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle complex NOT conditions", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) =>
+        (q, _params, h) =>
           q
             .from("users")
             .where(
               (u) =>
                 !(
-                  _.functions.istartsWith(u.name, "test") || _.functions.iendsWith(u.email, ".test")
+                  h.functions.istartsWith(u.name, "test") || h.functions.iendsWith(u.email, ".test")
                 ),
             ),
         { users: [] },

--- a/packages/tinqer-sql-pg-promise/package.json
+++ b/packages/tinqer-sql-pg-promise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer-sql-pg-promise",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "pg-promise SQL generator for Tinqer query builder",
   "type": "module",
   "main": "./dist/index.js",
@@ -19,7 +19,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@webpods/tinqer": "^0.0.13"
+    "@webpods/tinqer": "^0.0.14"
   },
   "devDependencies": {
     "@types/chai": "5.2.2",

--- a/packages/tinqer-sql-pg-promise/tests/case-insensitive-functions.test.ts
+++ b/packages/tinqer-sql-pg-promise/tests/case-insensitive-functions.test.ts
@@ -27,7 +27,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should generate LOWER() = LOWER() for iequals", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => _.functions.iequals(u.name, "John")),
+        (q, _params, h) => q.from("users").where((u) => h.functions.iequals(u.name, "John")),
         { users: [] },
       );
 
@@ -38,7 +38,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle column-to-column comparison", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => _.functions.iequals(u.name, u.email)),
+        (q, _params, h) => q.from("users").where((u) => h.functions.iequals(u.name, u.email)),
         { users: [] },
       );
 
@@ -49,8 +49,8 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle query parameters", () => {
       const result = selectStatement(
         schema,
-        (q, params, _) =>
-          q.from("users").where((u) => _.functions.iequals(u.name, params.searchName)),
+        (q, params, h) =>
+          q.from("users").where((u) => h.functions.iequals(u.name, params.searchName)),
         { users: [], searchName: "Alice" },
       );
 
@@ -65,7 +65,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should generate LOWER() LIKE LOWER() || '%' for istartsWith", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => _.functions.istartsWith(u.name, "J")),
+        (q, _params, h) => q.from("users").where((u) => h.functions.istartsWith(u.name, "J")),
         { users: [] },
       );
 
@@ -78,7 +78,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle complex prefix values", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => _.functions.istartsWith(u.email, "admin@")),
+        (q, _params, h) => q.from("users").where((u) => h.functions.istartsWith(u.email, "admin@")),
         { users: [] },
       );
 
@@ -93,7 +93,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should generate LOWER() LIKE '%' || LOWER() for iendsWith", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => _.functions.iendsWith(u.email, ".com")),
+        (q, _params, h) => q.from("users").where((u) => h.functions.iendsWith(u.email, ".com")),
         { users: [] },
       );
 
@@ -108,7 +108,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should generate LOWER() LIKE '%' || LOWER() || '%' for icontains", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => _.functions.icontains(u.bio!, "developer")),
+        (q, _params, h) => q.from("users").where((u) => h.functions.icontains(u.bio!, "developer")),
         { users: [] },
       );
 
@@ -121,7 +121,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle null-safe navigation", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => _.functions.icontains(u.bio!, "engineer")),
+        (q, _params, h) => q.from("users").where((u) => h.functions.icontains(u.bio!, "engineer")),
         { users: [] },
       );
 
@@ -136,8 +136,8 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle AND conditions", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) =>
-          q.from("users").where((u) => _.functions.iequals(u.name, "John") && u.age > 18),
+        (q, _params, h) =>
+          q.from("users").where((u) => h.functions.iequals(u.name, "John") && u.age > 18),
         { users: [] },
       );
 
@@ -150,11 +150,11 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle OR conditions", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) =>
+        (q, _params, h) =>
           q
             .from("users")
             .where(
-              (u) => _.functions.istartsWith(u.name, "A") || _.functions.istartsWith(u.name, "B"),
+              (u) => h.functions.istartsWith(u.name, "A") || h.functions.istartsWith(u.name, "B"),
             ),
         { users: [] },
       );
@@ -168,10 +168,10 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle mixed case-sensitive and case-insensitive operations", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) =>
+        (q, _params, h) =>
           q
             .from("users")
-            .where((u) => _.functions.icontains(u.email, "admin") && u.email.endsWith(".com")),
+            .where((u) => h.functions.icontains(u.email, "admin") && u.email.endsWith(".com")),
         { users: [] },
       );
 
@@ -184,10 +184,10 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should work with select projection", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) =>
+        (q, _params, h) =>
           q
             .from("users")
-            .where((u) => _.functions.iequals(u.role!, "ADMIN"))
+            .where((u) => h.functions.iequals(u.role!, "ADMIN"))
             .select((u) => ({
               id: u.id,
               name: u.name,
@@ -205,10 +205,10 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should work with orderBy", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) =>
+        (q, _params, h) =>
           q
             .from("users")
-            .where((u) => _.functions.icontains(u.bio!, "software"))
+            .where((u) => h.functions.icontains(u.bio!, "software"))
             .orderBy((u) => u.name),
         { users: [] },
       );
@@ -224,7 +224,7 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle NOT with iequals", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) => q.from("users").where((u) => !_.functions.iequals(u.role!, "admin")),
+        (q, _params, h) => q.from("users").where((u) => !h.functions.iequals(u.role!, "admin")),
         { users: [] },
       );
 
@@ -237,13 +237,13 @@ describe("Case-Insensitive Functions - SQL Generation", () => {
     it("should handle complex NOT conditions", () => {
       const result = selectStatement(
         schema,
-        (q, _params, _) =>
+        (q, _params, h) =>
           q
             .from("users")
             .where(
               (u) =>
                 !(
-                  _.functions.istartsWith(u.name, "test") || _.functions.iendsWith(u.email, ".test")
+                  h.functions.istartsWith(u.name, "test") || h.functions.iendsWith(u.email, ".test")
                 ),
             ),
         { users: [] },

--- a/packages/tinqer/package.json
+++ b/packages/tinqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "LINQ to SQL for TypeScript",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tinqer/src/visitors/types.ts
+++ b/packages/tinqer/src/visitors/types.ts
@@ -57,7 +57,7 @@ export interface VisitorContext {
   queryBuilderParam?: string; // DSL parameter name (ctx in (q, p, h) => q.from("users"))
   tableParams: Set<string>; // Table parameter names (x in x => x.name)
   queryParams: Set<string>; // Query parameter names (p in (p) => p.minAge)
-  helpersParam?: string; // Helpers parameter name (_ in (p, _) => _.functions.iequals)
+  helpersParam?: string; // Helpers parameter name (_ in (p, _) => h.functions.iequals)
   groupingParams?: Set<string>; // Grouping parameter names for aggregates
 
   // Auto-parameterization

--- a/packages/tinqer/src/visitors/where/case-insensitive-functions.ts
+++ b/packages/tinqer/src/visitors/where/case-insensitive-functions.ts
@@ -1,6 +1,6 @@
 /**
  * Case-insensitive function visitor for WHERE clauses
- * Handles helpers.functions.* calls like _.functions.iequals(a, b)
+ * Handles helpers.functions.* calls like h.functions.iequals(a, b)
  */
 
 import type {

--- a/packages/tinqer/src/visitors/where/context.ts
+++ b/packages/tinqer/src/visitors/where/context.ts
@@ -18,7 +18,7 @@ export interface WhereContext {
   // External query parameters (p in (p) => ...)
   queryParams: Set<string>;
 
-  // Helpers parameter (_ in (params, _) => _.functions.*)
+  // Helpers parameter (_ in (params, h) => h.functions.*)
   helpersParam?: string;
 
   // Auto-generated parameters for literals

--- a/packages/tinqer/src/visitors/where/predicate.ts
+++ b/packages/tinqer/src/visitors/where/predicate.ts
@@ -99,7 +99,7 @@ export function visitPredicate(
     }
 
     case "CallExpression": {
-      // Try case-insensitive functions first (_.functions.iequals)
+      // Try case-insensitive functions first (h.functions.iequals)
       const caseInsensitiveResult = visitCaseInsensitiveFunction(node as CallExpression, {
         ...context,
         autoParamCounter: currentCounter,

--- a/packages/tinqer/tests/case-insensitive-functions.test.ts
+++ b/packages/tinqer/tests/case-insensitive-functions.test.ts
@@ -29,13 +29,13 @@ interface TestSchema {
 
 describe("Case-Insensitive Functions - Parser", () => {
   describe("iequals function", () => {
-    it("should parse _.functions.iequals correctly", () => {
+    it("should parse h.functions.iequals correctly", () => {
       const result = parseQuery(
         (
           q: QueryBuilder<TestSchema>,
           _p: Record<string, never>,
-          _: ReturnType<typeof createQueryHelpers>,
-        ) => q.from("users").where((u) => _.functions.iequals(u.name, "John")),
+          h: ReturnType<typeof createQueryHelpers>,
+        ) => q.from("users").where((u) => h.functions.iequals(u.name, "John")),
       );
 
       expect(result).to.not.be.null;
@@ -75,8 +75,8 @@ describe("Case-Insensitive Functions - Parser", () => {
         (
           q: QueryBuilder<TestSchema>,
           _params: Record<string, never>,
-          _: ReturnType<typeof createQueryHelpers>,
-        ) => q.from("users").where((u) => _.functions.iequals(u.name, "TestUser")),
+          h: ReturnType<typeof createQueryHelpers>,
+        ) => q.from("users").where((u) => h.functions.iequals(u.name, "TestUser")),
       );
 
       expect(result).to.not.be.null;
@@ -88,13 +88,13 @@ describe("Case-Insensitive Functions - Parser", () => {
   });
 
   describe("istartsWith function", () => {
-    it("should parse _.functions.istartsWith correctly", () => {
+    it("should parse h.functions.istartsWith correctly", () => {
       const result = parseQuery(
         (
           q: QueryBuilder<TestSchema>,
           _params: Record<string, never>,
-          _: ReturnType<typeof createQueryHelpers>,
-        ) => q.from("users").where((u) => _.functions.istartsWith(u.name, "J")),
+          h: ReturnType<typeof createQueryHelpers>,
+        ) => q.from("users").where((u) => h.functions.istartsWith(u.name, "J")),
       );
 
       expect(result).to.not.be.null;
@@ -112,8 +112,8 @@ describe("Case-Insensitive Functions - Parser", () => {
         (
           q: QueryBuilder<TestSchema>,
           _params: Record<string, never>,
-          _: ReturnType<typeof createQueryHelpers>,
-        ) => q.from("users").where((u) => _.functions.istartsWith(u.email, u.name)),
+          h: ReturnType<typeof createQueryHelpers>,
+        ) => q.from("users").where((u) => h.functions.istartsWith(u.email, u.name)),
       );
 
       expect(result).to.not.be.null;
@@ -127,13 +127,13 @@ describe("Case-Insensitive Functions - Parser", () => {
   });
 
   describe("iendsWith function", () => {
-    it("should parse _.functions.iendsWith correctly", () => {
+    it("should parse h.functions.iendsWith correctly", () => {
       const result = parseQuery(
         (
           q: QueryBuilder<TestSchema>,
           _params: Record<string, never>,
-          _: ReturnType<typeof createQueryHelpers>,
-        ) => q.from("users").where((u) => _.functions.iendsWith(u.email, ".com")),
+          h: ReturnType<typeof createQueryHelpers>,
+        ) => q.from("users").where((u) => h.functions.iendsWith(u.email, ".com")),
       );
 
       expect(result).to.not.be.null;
@@ -147,13 +147,13 @@ describe("Case-Insensitive Functions - Parser", () => {
   });
 
   describe("icontains function", () => {
-    it("should parse _.functions.icontains correctly", () => {
+    it("should parse h.functions.icontains correctly", () => {
       const result = parseQuery(
         (
           q: QueryBuilder<TestSchema>,
           _p: Record<string, never>,
-          _: ReturnType<typeof createQueryHelpers>,
-        ) => q.from("users").where((u) => _.functions.icontains(u.bio!, "developer")),
+          h: ReturnType<typeof createQueryHelpers>,
+        ) => q.from("users").where((u) => h.functions.icontains(u.bio!, "developer")),
       );
 
       expect(result).to.not.be.null;
@@ -170,8 +170,8 @@ describe("Case-Insensitive Functions - Parser", () => {
         (
           q: QueryBuilder<TestSchema>,
           p: { searchTerm: string },
-          _: ReturnType<typeof createQueryHelpers>,
-        ) => q.from("users").where((u) => _.functions.icontains(u.bio!, p.searchTerm)),
+          h: ReturnType<typeof createQueryHelpers>,
+        ) => q.from("users").where((u) => h.functions.icontains(u.bio!, p.searchTerm)),
       );
 
       expect(result).to.not.be.null;
@@ -190,8 +190,8 @@ describe("Case-Insensitive Functions - Parser", () => {
         (
           q: QueryBuilder<TestSchema>,
           _p: Record<string, never>,
-          _: ReturnType<typeof createQueryHelpers>,
-        ) => q.from("users").where((u) => _.functions.iequals(u.name, "John") && u.age > 18),
+          h: ReturnType<typeof createQueryHelpers>,
+        ) => q.from("users").where((u) => h.functions.iequals(u.name, "John") && u.age > 18),
       );
 
       expect(result).to.not.be.null;
@@ -208,12 +208,12 @@ describe("Case-Insensitive Functions - Parser", () => {
         (
           q: QueryBuilder<TestSchema>,
           _p: Record<string, never>,
-          _: ReturnType<typeof createQueryHelpers>,
+          h: ReturnType<typeof createQueryHelpers>,
         ) =>
           q
             .from("users")
             .where(
-              (u) => _.functions.istartsWith(u.name, "A") || _.functions.istartsWith(u.name, "B"),
+              (u) => h.functions.istartsWith(u.name, "A") || h.functions.istartsWith(u.name, "B"),
             ),
       );
 
@@ -231,11 +231,11 @@ describe("Case-Insensitive Functions - Parser", () => {
         (
           q: QueryBuilder<TestSchema>,
           _p: Record<string, never>,
-          _: ReturnType<typeof createQueryHelpers>,
+          h: ReturnType<typeof createQueryHelpers>,
         ) =>
           q
             .from("users")
-            .where((u) => _.functions.icontains(u.email, "admin"))
+            .where((u) => h.functions.icontains(u.email, "admin"))
             .select((u) => ({
               id: u.id,
               name: u.name,
@@ -266,12 +266,8 @@ describe("Case-Insensitive Functions - Parser", () => {
 
     it("should not recognize invalid function names as case-insensitive", () => {
       // This will parse as a coalesce expression due to the ?? operator
-      const result = parseQuery(
-        (
-          q: QueryBuilder<TestSchema>,
-          _p: Record<string, never>,
-          _: ReturnType<typeof createQueryHelpers>,
-        ) => q.from("users").where((u) => u.name === "test" || false),
+      const result = parseQuery((q: QueryBuilder<TestSchema>) =>
+        q.from("users").where((u) => u.name === "test" || false),
       );
 
       expect(result).to.not.be.null;


### PR DESCRIPTION
- Changed helpers parameter from '_' to 'h' in all case-insensitive function tests
- Updated comments in visitor files to reflect 'h' naming convention
- Bumped version to 0.0.14 across all packages
- Updated peerDependencies to match new version
- Regenerated llms.txt documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)