### PR TITLE
docs: add OXC parser credits and bump patch versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,10 @@ See [Database Adapters](docs/adapters.md) for detailed comparison.
 | `@webpods/tinqer-sql-pg-promise`     | PostgreSQL adapter with pg-promise                       |
 | `@webpods/tinqer-sql-better-sqlite3` | SQLite adapter with better-sqlite3                       |
 
+## Credits
+
+Tinqer uses [OXC](https://oxc.rs/) - a fast JavaScript/TypeScript parser written in Rust - to parse lambda expressions at runtime. OXC's speed and reliability make Tinqer's runtime lambda parsing practical and performant.
+
 ## License
 
 MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@webpods/tinqer-monorepo",
-  "version": "0.0.11",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@webpods/tinqer-monorepo",
-      "version": "0.0.11",
+      "version": "0.0.14",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -4461,7 +4461,7 @@
     },
     "packages/tinqer": {
       "name": "@webpods/tinqer",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "MIT",
       "dependencies": {
         "oxc-parser": "^0.90.0"
@@ -4502,7 +4502,7 @@
     },
     "packages/tinqer-sql-better-sqlite3": {
       "name": "@webpods/tinqer-sql-better-sqlite3",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "MIT",
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",
@@ -4515,7 +4515,7 @@
         "typescript": "5.9.2"
       },
       "peerDependencies": {
-        "@webpods/tinqer": "^0.0.13"
+        "@webpods/tinqer": "^0.0.14"
       }
     },
     "packages/tinqer-sql-better-sqlite3-integration": {
@@ -4539,7 +4539,7 @@
     },
     "packages/tinqer-sql-pg-promise": {
       "name": "@webpods/tinqer-sql-pg-promise",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "5.2.2",
@@ -4552,7 +4552,7 @@
         "typescript": "5.9.2"
       },
       "peerDependencies": {
-        "@webpods/tinqer": "^0.0.13"
+        "@webpods/tinqer": "^0.0.14"
       }
     },
     "packages/tinqer-sql-pg-promise-integration": {

--- a/packages/tinqer-sql-better-sqlite3-integration/package.json
+++ b/packages/tinqer-sql-better-sqlite3-integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer-sql-better-sqlite3-integration",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "description": "SQLite integration tests for Tinqer using better-sqlite3",

--- a/packages/tinqer-sql-better-sqlite3/package.json
+++ b/packages/tinqer-sql-better-sqlite3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer-sql-better-sqlite3",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Better SQLite3 SQL generator for Tinqer query builder",
   "type": "module",
   "main": "./dist/index.js",
@@ -19,7 +19,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@webpods/tinqer": "^0.0.14"
+    "@webpods/tinqer": "^0.0.15"
   },
   "devDependencies": {
     "@types/chai": "5.2.2",

--- a/packages/tinqer-sql-pg-promise-integration/package.json
+++ b/packages/tinqer-sql-pg-promise-integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer-sql-pg-promise-integration",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "PostgreSQL integration tests for Tinqer using pg-promise",
   "type": "module",
   "private": true,

--- a/packages/tinqer-sql-pg-promise/package.json
+++ b/packages/tinqer-sql-pg-promise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer-sql-pg-promise",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "pg-promise SQL generator for Tinqer query builder",
   "type": "module",
   "main": "./dist/index.js",
@@ -19,7 +19,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@webpods/tinqer": "^0.0.14"
+    "@webpods/tinqer": "^0.0.15"
   },
   "devDependencies": {
     "@types/chai": "5.2.2",

--- a/packages/tinqer/package.json
+++ b/packages/tinqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpods/tinqer",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "LINQ to SQL for TypeScript",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
- Added Credits section to README acknowledging OXC parser
- Bumped main packages to v0.0.15 (tinqer, tinqer-sql-pg-promise, tinqer-sql-better-sqlite3)
- Bumped integration packages to v0.0.14
- Updated peer dependencies to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)